### PR TITLE
:sparkles: textimgで絵文字を描画できるようにするためのファイルと環境変数の追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,7 +45,8 @@ RUN --mount=type=cache,target=/root/go/src \
                 /tmp/go/src/github.com/YuheiNakasaka/sayhuuzoku/db/data.db \
     && mkdir -p /tmp/go/src/github.com/YuheiNakasaka/sayhuuzoku/scraping \
          && cp /root/go/src/github.com/YuheiNakasaka/sayhuuzoku/scraping/shoplist.txt \
-                /tmp/go/src/github.com/YuheiNakasaka/sayhuuzoku/scraping/shoplist.txt
+                /tmp/go/src/github.com/YuheiNakasaka/sayhuuzoku/scraping/shoplist.txt \
+    && git clone https://github.com/googlefonts/noto-emoji /usr/local/src/noto-emoji
 
 ## Ruby
 FROM base AS ruby-builder
@@ -289,9 +290,11 @@ COPY --from=go-builder /usr/local/go/LICENSE /usr/local/go/README.md /usr/local/
 COPY --from=go-builder /usr/local/go/bin/ /usr/local/go/bin/
 COPY --from=go-builder /root/go/bin /root/go/bin
 COPY --from=go-builder /tmp/go /root/go
+COPY --from=go-builder /usr/local/src/noto-emoji/png/128/ /usr/local/src/noto-emoji
 ENV GOPATH /root/go
 ENV PATH $PATH:/usr/local/go/bin:/root/go/bin
 RUN ln -s /root/go/src/github.com/YuheiNakasaka/sayhuuzoku/db /
+ENV TEXTIMG_EMOJI_DIR /usr/local/src/noto-emoji
 
 # Ruby
 COPY --from=ruby-builder /usr/local/bin /usr/local/bin


### PR DESCRIPTION
textimgをバージョンアップし、絵文字を描画できるようにしました。

```bash
% echo こんにち😃👍😅😄World | textimg -o a.png  
```
![a](https://user-images.githubusercontent.com/13825004/58804413-c909a600-864c-11e9-9ded-bcfa09c446cc.png)

関連して、絵文字描画の元になる画像ファイルと環境変数を追加するように
Dockerfileに追記しました。

noto-color-emojiがシェル芸bot環境内に存在するものの
描画のもとになるPNG画像のほうが存在しなかったので今回追加いたしました。
（Goの実装の都合で、Noto-Color-Emoji.ttfから絵文字を描画できない）

ご確認のほどよろしくお願いいたします。