### PR TITLE
add: kagome command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -298,6 +298,9 @@ RUN --mount=type=bind,target=/var/lib/apt/lists,from=apt-cache,source=/var/lib/a
       python3-pkg-resources\
       fonts-droid-fallback fonts-lato fonts-liberation fonts-noto-mono fonts-dejavu-core gsfonts
 
+# kagome
+COPY --from=ikawaha/kagome /usr/local/bin/kagome /usr/local/bin/kagome
+
 # Go
 COPY --from=go-builder /usr/local/go/LICENSE /usr/local/go/README.md /usr/local/go/
 COPY --from=go-builder /usr/local/go/bin /usr/local/go/bin

--- a/docker_image.bats
+++ b/docker_image.bats
@@ -774,3 +774,8 @@
   run w3m -version
   [[ "$output" =~ 'w3m version' ]]
 }
+
+@test "kagome" {
+  run kagome -h
+  [ "${lines[0]}" = 'Japanese Morphological Analyzer -- github.com/ikawaha/kagome' ]
+}


### PR DESCRIPTION
https://twitter.com/ikawaha/status/1141659391919382528 より

kagome のソースは辞書ファイルが含まれていて重いため、自前でビルドせず、DockerHub のイメージからビルド済みのバイナリのみ拝借します。