### PR TITLE
set VROOT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -390,7 +390,9 @@ RUN --mount=type=bind,target=/downloads,from=general-builder,source=/downloads \
 # V
 RUN --mount=type=bind,target=/downloads,from=general-builder,source=/downloads \
     unzip /downloads/v.zip -d /usr/local/vlang -x v_macos -x v.exe \
-    && ln -s /usr/local/vlang/v_linux /usr/local/bin/v
+    && ln -s /usr/local/vlang/v_linux /usr/local/bin/v \
+    && mkdir -p /root/.vlang \
+    && echo /usr/local/vlang > /root/.vlang/VROOT
 
 # PowerShell
 RUN --mount=type=bind,target=/downloads,from=general-builder,source=/downloads \


### PR DESCRIPTION
- #28 の対応漏れの修正です
- `$VROOT` 環境変数に vlang のルートディレクトリを設定した状態で何かをビルドすると、`$HOME/.vlang/VROOT` に `$VROOT` が保存され、以後は `$VROOT` 環境変数が不要になるようでした
    - 修正前にビルドがこけていたのも、`VROOT` 設定がなかったのが原因のようでした
- `$HOME/.vlang/VROOT` が設定されていないと、初回設定するよってメッセージが出て煩わしかったので環境変数ではなく直接 `VROOT` ファイルを設定するようにしました
