### PR TITLE
remove: strace

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -237,7 +237,6 @@ RUN --mount=type=bind,target=/var/lib/apt/lists,from=apt-cache,source=/var/lib/a
       nyancat\
       imagemagick ghostscript\
       moreutils\
-      strace\
       whiptail\
       pandoc\
       postgresql-common\

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ docker container run --rm \
   --net=none \
   --oom-kill-disable \
   --pids-limit=1024 \
-  --cap-add=sys_ptrace \
   -v $(pwd):/root/src \
   shellgeibot \
   /bin/bash -c "bats /root/src/docker_image.bats"

--- a/docker_image.bats
+++ b/docker_image.bats
@@ -233,11 +233,6 @@
   [ "$output" = "EPERM 1 許可されていない操作です" ]
 }
 
-@test "strace" {
-  run strace -V
-  [[ "${lines[0]}" =~ "strace -- version" ]]
-}
-
 @test "whiptail" {
   run whiptail -v
   [[ "$output" =~ "whiptail" ]]


### PR DESCRIPTION
- シェル芸bot 本体で `--cap-add sys_ptrace` が外れたので、足並みを揃えておく
- strace が動かなくなるので削除