### PR TITLE
textchatコマンドの追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN --mount=type=cache,target=/root/go/src \
       github.com/jiro4989/align \
       github.com/jiro4989/taishoku \
       github.com/jiro4989/textimg \
+      github.com/jiro4989/textchat \
       github.com/greymd/ojichat \
       github.com/ikawaha/nise \
       github.com/jmhobbs/terminal-parrot \

--- a/docker_image.bats
+++ b/docker_image.bats
@@ -868,6 +868,11 @@
   [ "$output" == "シェル芸" ]
 }
 
+@test "5ktrillion" {
+  run bash -c "5ktrillion -5"
+  [ "$output" = '5000兆円欲しい！' ]
+}
+
 @test "terminal-parrot" {
   run terminal-parrot -h
   [ $status -eq 2 ]
@@ -878,3 +883,11 @@
   run cmatrix -h
   [[ "${lines[0]}" =~ 'Usage: cmatrix' ]]
 }
+
+@test "textchat" {
+  run bash -c "textchat -n bob hello"
+  [ "$output" = ".-----.  .---------.                                                            
+| bob | <   hello  |                                                            
+\`-----'  \`---------'                                                            " ]
+}
+


### PR DESCRIPTION
手前味噌で恐縮なのですが、textchatコマンドを追加していただけませんでしょうか :question: 
よろしくお願いいたします。

あと5ktrillionコマンドのテストが抜けてたので追加しました。
(後からコマンドを追加してテストの方を追加し忘れた）

```bash
$ unko.shout | textchat
.------.  .----------------------------.                                        
| 田辺 | <   ＿人人人人人人＿          |                                        
`------'  |  ＞　突然の死　＜          |                                        
          |  ￣Y^Y^Y^Y^Y^Y^￣          |                                        
          |  　　　　　　👑            |                                        
          |  　　　　（💩💩💩）        |                                        
          |  　　　（💩👁💩👁💩）      |                                        
          |  　　（💩💩💩👃💩💩💩）    |                                        
          |  　（💩💩💩💩👄💩💩💩💩）  |                                        
          `----------------------------'                                        

$ textchat -r -i <(unko.tower) $(ojichat) -p '　'
.----------------------------------------------------.  .----------------------.
|  章江ﾁｬﾝ、お疲れ様〜(^з<)🎵😃☀ そういえば、昨日   > | 　　　　　人         |
|  は例の中華🍜に行ってきたよ。結構いい雰囲気だった  |  | 　　　（　　　）     |
|  から、オススメだヨ🎵                              |  | 　　（　　　　　）   |
`----------------------------------------------------'  | 　（　　　　　　　） |
　　　　　　　　　　　　　　　　　　　　　　　　　　　　`----------------------'
```