### PR TITLE
Enable conversion from SVG to PNG

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -282,7 +282,8 @@ RUN --mount=type=bind,target=/var/lib/apt/lists,from=apt-cache,source=/var/lib/a
       bf\
       libc++-dev\
       mono-csharp-shell\
-      ipcalc
+      ipcalc\
+      librsvg2-bin
 
 # kagome
 COPY --from=ikawaha/kagome /usr/local/bin/kagome /usr/local/bin/kagome

--- a/docker_image.bats
+++ b/docker_image.bats
@@ -906,3 +906,8 @@
   run bash -c "echo -n unko | chant | chant -d"
   [ "$output" = "unko" ]
 }
+
+@test "rsvg-convert" {
+  run rsvg-convert -v
+  [[ ${output} =~ 'rsvg-convert version' ]]
+}


### PR DESCRIPTION
- ImageMagick で SVG から PNG に変換しようとすると、エラーを吐いてしまう

```sh
$ convert sample.svg sample.png
convert-im6.q16: delegate failed `'rsvg-convert' -o '%o' '%i'' @ error/delegate.c/InvokeDelegate/1919.
convert-im6.q16: unable to open file `/tmp/magick-12RYcG8LRKAv6t': そのようなファイルやディレクトリはありません @ error/constitute.c/ReadImage/600.
convert-im6.q16: no images defined `sample.png' @ error/convert.c/ConvertImageCommand/3258.
```

- ImageMagick が外部コマンドを呼び出す(delegate)手段は `/etc/ImageMagick-6/delegates.xml` で定義されていて、以下のコマンドで確認できる
  - 上記エラーの原因は `convert` からで呼び出される `rsvg-convert` がインストールされていないため

```sh
$ convert -list delegate | grep 'svg =>'
        svg =>          "rsvg-convert' -o '%o' '%i"

```

- `rsvg-convert` は `librsvg2-bin` パッケージでインストールできるようなので、追加したいと思います
