### PR TITLE
Add ponpe command.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,6 +34,7 @@ RUN --mount=type=cache,target=/root/go/src \
       github.com/jiro4989/taishoku \
       github.com/jiro4989/textimg \
       github.com/jiro4989/textchat \
+      github.com/jiro4989/ponpe \
       github.com/greymd/ojichat \
       github.com/ikawaha/nise \
       github.com/jmhobbs/terminal-parrot \

--- a/docker_image.bats
+++ b/docker_image.bats
@@ -950,3 +950,8 @@
   run muscular
   [ "${lines[0]}" = 'Usage: muscular [command]' ]
 }
+
+@test "ponpe" {
+  run ponpe ponponpain haraita-i
+  [ "$output" = 'pͪoͣnⷢpͣoꙶnͭpͣa͡iꙶn' ]
+}


### PR DESCRIPTION
手前味噌で恐縮なのですが
アルファベットを結合してpͪoͣnⷢpͣoꙶnͭpͣa͡iꙶnなどの文字を生成するコマンドを追加していただけませんでしょうか。

```bash
$ ponpe ponponpain haraita-i
pͪoͣnⷢpͣoꙶnͭpͣa͡iꙶn

$ echo date | ponpe - -
dͩaͣtͭeͤ
```

宜しくお願いいたします。