### PR TITLE
出力をテストするように修正

### DIFF
--- a/docker_image.bats
+++ b/docker_image.bats
@@ -947,6 +947,6 @@
 }
 
 @test "muscular" {
-  run muscular
-  [ "${lines[0]}" = 'Usage: muscular [command]' ]
+  run bash -c "muscular shout ナイスバルク | grep -P -o '\p{Katakana}'|tr -d '\n'"
+  [ "${lines[0]}" = 'ナイスバルク' ]
 }


### PR DESCRIPTION
muscularコマンドについて、出力が正しいか動作確認のテストにしていなかった
ため、バグを生じさせてしまっていました。
コマンド自体を修正し、またテストも出力を確認する正しいものに修正しましたので、  
すみませんがマージしていただけると幸いです。

```text
   ,~-,    .-,    r~-.    
  / r-d   /   \   `w`,\   
,7 /      \   /      \ \  
/  ^"`-'v/'`-y|`"'-"^-` ) 
`\,_ _,;,   ,     A,,  /  ＿人人＿
    "'\ `:,.'`..,`)' `'   ＞ ご ＜
       \ ,  ;, ,,r`       ＞ 迷 ＜
        `, .,.` )         ＞ 惑 ＜
         ) `;.  }         ＞ お ＜
         |._,,_.|         ＞ か ＜
         ^\    .'.        ＞ け ＜
        /  \, /  \,       ＞ し ＜
        | ; `/ `  )       ＞ て ＜
        | ,  |  . |       ＞ す ＜
        \,`,,A ;`,}       ＞ み ＜
        ';  ) \   ,       ＞ ま ＜
         \',/  (  }       ＞ せ ＜
         \  \  /  |       ＞ ん ＜
          ( ,)(   ,       ￣Y^Y^￣
          \ ;} :`/        
           \ | )V         
            )\| |         
         ,^'_}?__`,   
```