### PR TITLE
update: Ubuntu 19.10 移行

### DIFF
--- a/docker_image.bats
+++ b/docker_image.bats
@@ -362,7 +362,7 @@
 }
 
 @test "chromium" {
-  run chromium-browser --version
+  run chrome --version
   [[ "$output" =~ "Chromium" ]]
 }
 


### PR DESCRIPTION
- close #77
- chromium-browser が snap 版になったので、パッケージマネージャーを利用せず、バイナリをダウンロードして配置
- .NET Core のリポジトリが (まだ) 提供されていないため、バイナリをダウンロードして配置
    - .NET Core 3.0 ではなく 2.2 なのは、noc が 2.1 向けで 3.0 では動かなかったため