### PR TITLE
edensコマンドを追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,6 +116,7 @@ RUN find /root/.rustup /root/.cargo -type f \
 
 ## Nim
 FROM base AS nim-builder
+ENV PATH $PATH:/root/.nimble/bin
 RUN curl https://nim-lang.org/choosenim/init.sh -sSf > init.sh \
     && sh init.sh -y \
     && choosenim update stable

--- a/Dockerfile
+++ b/Dockerfile
@@ -116,13 +116,10 @@ RUN find /root/.rustup /root/.cargo -type f \
 
 ## Nim
 FROM base AS nim-builder
-RUN --mount=type=bind,target=/var/lib/apt/lists,from=apt-cache,source=/var/lib/apt/lists \
-    --mount=type=cache,target=/var/cache/apt,sharing=private \
-    apt-get install -y -qq nim
-RUN nimble install rect -Y
-RUN curl --retry 3 -sfSLO https://github.com/jiro4989/maze/releases/latest/download/maze_linux.tar.gz \
-    && tar xzf maze_linux.tar.gz \
-    && install -m 0755 maze_linux/bin/maze $HOME/.nimble/bin/maze
+RUN curl https://nim-lang.org/choosenim/init.sh -sSf > init.sh \
+    && sh init.sh -y \
+    && choosenim update stable
+RUN nimble install rect edens maze -Y
 
 ## General
 FROM base AS general-builder

--- a/docker_image.bats
+++ b/docker_image.bats
@@ -1026,3 +1026,8 @@
   run maze
   [ "$status" -eq 0 ]
 }
+
+@test "edens" {
+  run edens -h
+  [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
任意の辞書ファイルやコマンドラインからの指定で文字をエンコード・デコードするツールをしていただきたいです。

※追加に際して、Nimを最新版1.0.2に上げたかったのでNimのインストール方法を変更しました

```bash
$ edens kakikokera <<< 寿司
杮杮杮柿柿杮柿杮杮柿杮柿杮杮杮杮杮柿杮杮杮杮杮杮杮杮杮柿柿杮柿杮杮柿柿柿杮杮杮杮杮柿杮杮杮柿柿柿

$ edens -w ふるつきさん -w ありがとう！ <<< 感謝
ありがとう！ありがとう！ありがとう！ふるつきさんふるつきさんありがとう！ありがとう！ふるつきさんありがとう！ふるつきさんふるつきさんふるつきさんふるつきさんありがとう！ふるつきさんふるつきさんありがとう！ふるつきさんふるつきさんありがとう！ありがとう！ありがとう！ありがとう！ありがとう！ありがとう！ありがとう！ありがとう！ふるつきさんありがとう！ふるつきさんふるつきさんふるつきさんありがとう！ふるつきさんありがとう！ふるつきさんありがとう！ありがとう！ふるつきさんふるつきさんありがとう！ふるつきさんふるつきさんありがとう！ありがとう！ありがとう！ふるつきさんありがとう！

$ edens -w ふるつきさん -w ありがとう！ <<< 感謝 | edens -w ふるつきさん -w ありがとう！ -d
感謝
```
