### PR TITLE
ImageMagickと連携するためのコマンドを追加

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,7 +121,7 @@ ENV PATH $PATH:/root/.nimble/bin
 RUN curl https://nim-lang.org/choosenim/init.sh -sSf > init.sh \
     && sh init.sh -y \
     && choosenim update stable
-RUN nimble install rect edens maze gyaric -Y
+RUN nimble install rect edens maze gyaric svgo -Y
 
 ## General
 FROM base AS general-builder


### PR DESCRIPTION
ImageMagickでアニメーションGIFを生成するときに複数のSVGを結合してアニメーションGIFを作成できます。
アニメーションGIF用のSVGを生成するためのツールを追加していただけませんでしょうか。

```bash
$ (seq 1 10 100; seq 100 -10 0) | svgo [ circle cx=100 cy=100 r='$1' ] -in -w 3 -o 'out_$NR.svg'
$ convert -resize 200x200 out_*.svg anim1.gif
```

![anim1](https://user-images.githubusercontent.com/13825004/75628969-53555980-5c21-11ea-8c7e-cecbfda44575.gif)
