### PR TITLE
Change lolcat installation from apt to gem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ RUN --mount=type=bind,target=/var/lib/apt/lists,from=apt-cache,source=/var/lib/a
     --mount=type=cache,target=/var/cache/apt,sharing=private \
     apt-get install -y -qq ruby-dev
 RUN --mount=type=cache,target=/root/.gem \
-    gem install --quiet --no-ri --no-rdoc cureutils matsuya takarabako snacknomama rubipara marky_markov zen_to_i
+    gem install --quiet --no-ri --no-rdoc cureutils lolcat matsuya takarabako snacknomama rubipara marky_markov zen_to_i
 RUN curl -sfSL --retry 3 https://raw.githubusercontent.com/hostilefork/whitespacers/master/ruby/whitespace.rb -o /usr/local/bin/whitespace
 RUN chmod +x /usr/local/bin/whitespace
 RUN curl -sfSL --retry 3 https://raw.githubusercontent.com/thisredone/rb/master/rb -o /usr/local/bin/rb && chmod +x /usr/local/bin/rb
@@ -279,7 +279,6 @@ RUN --mount=type=bind,target=/var/lib/apt/lists,from=apt-cache,source=/var/lib/a
       num-utils\
       apache2-utils\
       fish\
-      lolcat\
       nyancat\
       imagemagick ghostscript\
       moreutils\


### PR DESCRIPTION
`lolcat`コマンドについて:
現在APTでインストールされているバージョンが2011年の`42.0.99`なのに対し、RubyGemsの最新バージョンは2020年の`100.0.1`なので、gemからインストールされるように変更したいです。
これにより行番号をつける`-n`、24-bit(truecolor)の色コードを用いる`-t`、色を反転させる`-i`が使えるようになります。
よろしくお願いします。