### PR TITLE
insecure curl request due to certification expired

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -146,8 +146,8 @@ RUN git clone --depth 1 https://github.com/dbro/csvquote.git \
     && (cd csvquote && make)
 
 # unicode data
-RUN curl -sfSLO --retry 3 https://www.unicode.org/Public/UCD/latest/ucd/NormalizationTest.txt
-RUN curl -sfSLO --retry 3 https://www.unicode.org/Public/UCD/latest/ucd/NamesList.txt
+RUN curl -sfSLO --retry 3 --insecure https://www.unicode.org/Public/UCD/latest/ucd/NormalizationTest.txt
+RUN curl -sfSLO --retry 3 --insecure https://www.unicode.org/Public/UCD/latest/ucd/NamesList.txt
 
 # egison
 RUN curl -sfSLO --retry 3 https://git.io/egison.x86_64.deb


### PR DESCRIPTION
www.unicode.org 復活しているようですが、証明書の期限が切れているみたいなので、一時的に insecureオプションを付けて対応しようと思います。向こうが修正されたらこちらも戻そうかなと