### PR TITLE
Keep compatibility egison and egzact

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -153,9 +153,9 @@ RUN curl -sfSLO --retry 3 --insecure https://www.unicode.org/Public/UCD/latest/u
 RUN curl -sfSLO --retry 3 --insecure https://www.unicode.org/Public/UCD/latest/ucd/NamesList.txt
 
 # egison
-RUN curl -sfSLO --retry 3 https://git.io/egison.x86_64.deb
+RUN curl -sfSLO --retry 3 https://github.com/egison/egison-package-builder/releases/download/3.10.3/egison-3.10.3.x86_64.deb
 # egzact
-RUN curl -sfSLO --retry 3 https://git.io/egzact.deb
+RUN curl -sfSLO --retry 3 https://github.com/greymd/egzact/releases/download/v1.3.2/egzact-1.3.2.deb
 # bat
 RUN curl -sfSL --retry 3 https://github.com/sharkdp/bat/releases/download/v0.13.0/bat_0.13.0_amd64.deb -o bat.deb
 # osquery

--- a/Dockerfile
+++ b/Dockerfile
@@ -396,8 +396,8 @@ RUN --mount=type=bind,target=/downloads,from=general-builder,source=/downloads \
 # egison, egzact, bat, osquery, super_unko, echo-meme, J
 RUN --mount=type=bind,target=/downloads,from=general-builder,source=/downloads \
     dpkg -i \
-      /downloads/egison.x86_64.deb \
-      /downloads/egzact.deb \
+      /downloads/egison-3.10.3.x86_64.deb \
+      /downloads/egzact-1.3.2.deb \
       /downloads/bat.deb \
       /downloads/osquery.deb \
       /downloads/superunko.deb \


### PR DESCRIPTION
一旦互換性のあるegison 3.10.3 と egzact 1.3.2 に戻すPRです #96 