### PR TITLE
fix: rargs test

### DIFF
--- a/docker_image.bats
+++ b/docker_image.bats
@@ -638,7 +638,7 @@
 @test "rargs" {
   run rargs --help
   [[ "${lines[0]}" =~ "Rargs " ]]
-  [ "${lines[2]}" = 'Xargs with pattern matching' ]
+  [ "${lines[1]}" = 'Xargs with pattern matching' ]
 }
 
 @test "ShellGeiData" {


### PR DESCRIPTION
- [rargs v0.3.0](https://github.com/lotabout/rargs/releases/tag/v0.3.0) で `--help` の出力が変わったのに対応