### PR TITLE
.NET Core バージョンアップ

### DIFF
--- a/docker_image.bats
+++ b/docker_image.bats
@@ -174,7 +174,7 @@
 
 @test "dotnet" {
   run dotnet --help
-  [[ "${lines[0]}" =~ ".NET Command Line Tools" ]]
+  [ "${lines[3]}" = "Usage: dotnet [host-options] [path-to-application]" ]
 }
 
 @test "echo-meme" {


### PR DESCRIPTION
- dotnet core のバージョンを 2.1 から 3.1 に更新
    - noc のターゲットフレームワークを 2.1 から 3.1 に変更してもらった : https://twitter.com/xztaityozx_001/status/1295364030798823426
- dotnet SDK / Runtime は 元々 apt でインストールしていたけど、#79 で Ubuntu 19.10 移行時にバイナリを直接ダウンロードするように変更していた
  - Ubuntu 20.04 向けのリポジトリが提供されているため、apt でインストールするように戻した