### PR TITLE
update Ubuntu 20.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - checkout
       - setup_remote_docker:
           # docker_layer_caching: true  # 有償オプション
-          version: "19.03.8"
+          version: "19.03.13"
       - run:
           name: Build Docker image
           command: |
@@ -26,7 +26,7 @@ jobs:
             apk add --no-progress nodejs npm
             npm_config_unsafe_perm=true npm install --global --silent --no-progress tap-xunit
             mkdir -p ~/reports
-            docker create -v /root/src --name source ubuntu:20.04 /bin/true
+            docker create -v /root/src --name source ubuntu:20.10 /bin/true
             docker cp docker_image.bats source:/root/src
             docker container run --net=none --rm --volumes-from source ${DOCKER_IMAGE} \
               /bin/bash -c "bats --tap /root/src/docker_image.bats || true" | tee result.tap

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # syntax = docker/dockerfile:1.0-experimental
-FROM ubuntu:20.04 AS apt-cache
+FROM ubuntu:20.10 AS apt-cache
 
 RUN apt-get update
 
-FROM ubuntu:20.04 AS base
+FROM ubuntu:20.10 AS base
 ENV DEBIAN_FRONTEND noninteractive
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; \
     echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
@@ -96,7 +96,7 @@ FROM base AS dotnet-builder
 RUN --mount=type=bind,target=/var/lib/apt/lists,from=apt-cache,source=/var/lib/apt/lists \
     --mount=type=cache,target=/var/cache/apt,sharing=private \
     apt-get install -y -qq apt-transport-https
-RUN curl -sfSLO --retry 5 https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb \
+RUN curl -sfSLO --retry 5 https://packages.microsoft.com/config/ubuntu/20.10/packages-microsoft-prod.deb \
     && dpkg -i packages-microsoft-prod.deb
 RUN --mount=type=bind,target=/var/lib/apt/lists,from=apt-cache,source=/var/lib/apt/lists,rw \
     --mount=type=cache,target=/var/cache/apt,sharing=private \
@@ -362,7 +362,7 @@ COPY --from=nodejs-builder /usr/local/lib/node_modules /usr/local/lib/node_modul
 RUN --mount=type=bind,target=/var/lib/apt/lists,from=apt-cache,source=/var/lib/apt/lists \
     --mount=type=cache,target=/var/cache/apt,sharing=private \
     apt-get install -y -qq apt-transport-https
-RUN curl -sfSLO --retry 5 https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb \
+RUN curl -sfSLO --retry 5 https://packages.microsoft.com/config/ubuntu/20.10/packages-microsoft-prod.deb \
     && dpkg -i packages-microsoft-prod.deb \
     && rm packages-microsoft-prod.deb
 RUN --mount=type=bind,target=/var/lib/apt/lists,from=apt-cache,source=/var/lib/apt/lists,rw \
@@ -444,7 +444,7 @@ RUN mv /usr/bin/man.REAL /usr/bin/man
 
 # reset apt config
 RUN rm /etc/apt/apt.conf.d/keep-cache /etc/apt/apt.conf.d/no-install-recommends
-COPY --from=ubuntu:20.04 /etc/apt/apt.conf.d/docker-clean /etc/apt/apt.conf.d/
+COPY --from=ubuntu:20.10 /etc/apt/apt.conf.d/docker-clean /etc/apt/apt.conf.d/
 
 # ShellgeiBot-Image information
 RUN mkdir -p /etc/shellgeibot-image

--- a/Dockerfile
+++ b/Dockerfile
@@ -231,7 +231,7 @@ RUN git clone --depth 1 http://github.com/possatti/pokemonsay \
 ENV PATH $PATH:/root/bin
 
 # saizeriya
-RUN curl -sfSL --retry 5 https://raw.githubusercontent.com/horo17/saizeriya/master/saizeriya -o /usr/local/bin/saizeriya \
+RUN curl -sfSL --retry 5 https://raw.githubusercontent.com/3socha/saizeriya/master/saizeriya -o /usr/local/bin/saizeriya \
     && chmod u+x /usr/local/bin/saizeriya
 
 # fujiaire


### PR DESCRIPTION
- Groovy Golilla 対応
- [.NET Core 3.1.9](https://github.com/dotnet/core/blob/master/release-notes/3.1/3.1.9/3.1.9.md#net-core-lifecycle-news) で Ubuntu 20.10 がサポート対象になったけど、2020.10.25 時点では[まだ作業中](https://github.com/dotnet/core/issues/5017)で、うまく入らないようなので一旦 Draft Pull Request にしておく
  - Ubuntu 20.10 用の リポジトリは用意されてるけど、`https://packages.microsoft.com/config/ubuntu/20.10/packages-microsoft-prod.deb` から降ってくるファイルのうち、 `/etc/apt/sources.list.d/microsoft-prod.list` が指してるバージョンが groovy ではなく xenial になってる
  - Ubuntu 20.10 では libicu67 に更新されてるけど、dotnet-sdk-3.1 は libicu66 未満に依存してる： https://github.com/dotnet/core/issues/5352