### PR TITLE
Spike

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -143,6 +143,8 @@ RUN git clone --depth 1 https://github.com/bartobri/no-more-secrets.git \
     && (cd no-more-secrets && make nms-ncurses && make sneakers-ncurses)
 # shellgei data
 RUN git clone --depth 1 https://github.com/ryuichiueda/ShellGeiData.git
+# eki
+RUN git clone --depth 1 https://github.com/ryuichiueda/eki.git
 # imgout
 RUN git clone --depth 1 https://github.com/ryuichiueda/ImageGeneratorForShBot.git
 # csvquote

--- a/Dockerfile
+++ b/Dockerfile
@@ -394,6 +394,9 @@ ENV PATH $PATH:/root/.nimble/bin
 
 # shellgei data
 COPY --from=general-builder /downloads/ShellGeiData /ShellGeiData
+# eki
+COPY --from=general-builder /downloads/eki/eki /eki
+COPY --from=general-builder /downloads/eki/bin/eki /usr/local/bin/
 # imgout
 RUN --mount=type=bind,target=/downloads,from=general-builder,source=/downloads \
     (cd /downloads/ImageGeneratorForShBot && git archive --format=tar --prefix=imgout/ HEAD) | tar xf - -C /usr/local

--- a/docker_image.bats
+++ b/docker_image.bats
@@ -213,6 +213,10 @@
   [ "${lines[1]}" = 'シェル芸' ]
 }
 
+@test "eki" {
+  eki | grep -q 京急川崎
+}
+
 @test "Emacs" {
   run bash -c "echo シェル芸 | emacs -Q --batch --insert /dev/stdin --eval='(princ (buffer-string))'"
   [ "$output" = シェル芸 ]


### PR DESCRIPTION
Eki command and data are added to this branch. Though the size is large as 180MB, I think many people will enjoy this.


* an usage example of the eki command:

```bash
$ eki | head -n 3
JR函館本線(函館～長万部) 函館
JR函館本線(函館～長万部) 五稜郭
JR函館本線(函館～長万部) 桔梗
```