### PR TITLE
add idn command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -285,6 +285,7 @@ RUN --mount=type=bind,target=/var/lib/apt/lists,from=apt-cache,source=/var/lib/a
      graphviz \
      haskell-platform \
      icu-devtools \
+     idn \
      imagemagick ghostscript \
      ipcalc \
      jq \

--- a/docker_image.bats
+++ b/docker_image.bats
@@ -372,6 +372,11 @@
   [ "$output" = 'unko' ]
 }
 
+@test "idn" {
+  run idn うんこ.com
+  [ "$output" = 'xn--p8j0a9n.com' ]
+}
+
 @test "ImageMagick" {
   run convert -version
   [[ "${lines[0]}" =~ "Version: ImageMagick" ]]


### PR DESCRIPTION
punycodeの国際化ドメインをdecode/encodeするコマンド`idn`を追加して頂きたいです。

```bash
$ idn うんこ.com
xn--p8j0a9n.com
$ idn -u xn--p8j0a9n.com
うんこ.com
$ idn うんこ
xn--p8j0a9n
$ idn -u xn--p8j0a9n
うんこ
```