### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -149,7 +149,7 @@ RUN git clone --depth 1 https://github.com/dbro/csvquote.git \
 RUN git clone --depth 1 https://github.com/ryuichiueda/GlueLang.git \
     && (cd GlueLang && make)
 RUN git clone --depth 1 https://github.com/ryuichiueda/glueutils.git \
-    && (cd glueutils && mkdir bin && make)
+    && (cd glueutils && mkdir -p bin && make)
 
 # egison
 RUN curl -sfSLO --retry 5 https://github.com/egison/egison-package-builder/releases/download/4.0.0/egison-4.0.0.x86_64.deb


### PR DESCRIPTION
#145 の修正で、 `glueutils` のリポジトリにもともと `bin` ディレクトリがあるのを見逃していたので、 `-p` をつけて`bin`ディレクトリの存在如何に関わらず`bin`を作ります