### PR TITLE
fix: rustc test

### DIFF
--- a/docker_image.bats
+++ b/docker_image.bats
@@ -815,7 +815,7 @@
 @test "rustc" {
   run rustc --help
   [ $status -ne 0 ]
-  [ "$output" = 'error: no override and no default toolchain set' ]
+  [[ "$output" =~ 'error: no override and no default toolchain set' ]]
 }
 
 @test "rustup" {


### PR DESCRIPTION
- rustc 実行時のエラーメッセージが変わったのに対応
    - （シェル芸Botイメージ自体には Rust ツールチェインを含めていないためこのメッセージが出る）

```diff
- error: no override and no default toolchain set
+ error: no override and no default toolchain set; run 'rustup default stable' to set the stable toolchain as default 
```