### PR TITLE
Update build environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
       - checkout
       - setup_remote_docker:
           # docker_layer_caching: true  # 有償オプション
-          version: "19.03.13"
+          version: "20.10.2"
       - run:
           name: Build Docker image
           command: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax = docker/dockerfile:1.0-experimental
+# syntax = docker/dockerfile:1.2
 FROM ubuntu:20.10 AS apt-cache
 RUN apt-get update
 


### PR DESCRIPTION
- Dockerfile frontend で experimental 扱いだった [syntax](https://github.com/moby/buildkit/blob/master/frontend/dockerfile/docs/syntax.md) が正式に使えるようになっているため記述を修正
- CircleCI の [Remote docker](https://circleci.com/docs/2.0/building-docker-images/#docker-version) で 20.10.2 が使えるようになっているため更新
- シェル芸botの動作自体には影響がない想定