### PR TITLE
Emacs-nox

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -332,7 +332,7 @@ RUN --mount=type=bind,target=/var/lib/apt/lists,from=apt-cache,source=/var/lib/a
      tree \
      ttyrec \
      unicode-data uniutils \
-     vim emacs \
+     vim emacs-nox \
      w3m nginx \
      whiptail \
      xvfb xterm x11-apps xdotool \


### PR DESCRIPTION
 GUIいらないなあと思ったのでXサポート抜きの[emacs-nox](https://packages.ubuntu.com/hirsute/emacs-nox)にEmacsを置き換えます。