### PR TITLE
fix: Nim install error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,9 +116,9 @@ RUN find /root/.rustup /root/.cargo -type f \
 ## Nim
 FROM base AS nim-builder
 ENV PATH $PATH:/root/.nimble/bin
-RUN curl https://nim-lang.org/choosenim/init.sh -sSf > init.sh \
-    && sh init.sh -y \
-    && choosenim update stable
+RUN curl -sfSLO --retry 5 https://nim-lang.org/choosenim/init.sh
+RUN bash init.sh -y
+RUN choosenim update stable
 RUN nimble install edens gyaric maze rect svgo eachdo -Y
 
 ## General


### PR DESCRIPTION
## 現象
- [ビルド1245](https://app.circleci.com/pipelines/github/theoremoon/ShellgeiBot-Image/894/workflows/428c82df-1a6c-4cc7-bacc-3f68cac1c457/jobs/1245) が失敗

<details>
<summary>
ビルドログ抜粋
</summary>

```log
#93 [nim-builder 1/2] RUN curl https://nim-lang.org/choosenim/init.sh -sSf >...
#93 16.44    Building Nim 1.4.8
#93 16.44   Compiler: Already built
#93 16.44      Tools: Already built
#93 16.55   Installed component 'nim'
#93 16.55   Installed component 'nimble'
#93 16.55   Installed component 'nimgrep'
#93 16.58   Installed component 'nimpretty'
#93 16.58   Installed component 'nimsuggest'
#93 16.58   Installed component 'testament'
#93 16.58   Installed component 'nim-gdb'
#93 16.58    Switched to Nim 1.4.8
#93 16.64 choosenim-init: ChooseNim installed in /root/.nimble/bin
#93 16.64 choosenim-init: You must now ensure that the Nimble bin dir is in your PATH.
#93 16.64 choosenim-init: Place the following line in the ~/.profile or ~/.bashrc file.
#93 16.64 choosenim-init:     export PATH=/root/.nimble/bin:$PATH
#93 16.64 init.sh: 90: SHELL: parameter not set
#93 ERROR: executor failed running [/bin/sh -c curl https://nim-lang.org/choosenim/init.sh -sSf > init.sh     && sh init.sh -y     && choosenim update stable]: exit code: 2
```

</details>

## 要因

- https://github.com/theoremoon/ShellgeiBot-Image/blob/e02412ffa4ce0b0153254072ce450be5fcfccde1/Dockerfile#L119-L121 で取得・実行している choosenim/init.sh で、未定義の変数 `SHELL` を参照してしまっている
    - `sh init.sh -y` でスクリプトを実行しているが、Ubuntu の sh (dash) は `SHELL` 変数をセットしない
    - スクリプトに `set -u` が設定されているためエラー終了している
- https://github.com/dom96/choosenim/pull/214 でだいぶ前に入った修正のようだが、最近 nim-lang.org に置かれているファイルが更新されたんだろうか、詳細は不明

## 対応

- sh ではなく bash で実行すれば `SHELL` 変数が設定されるはず
- ついでにちょっとだけリファクタする
