### PR TITLE
add: base85 command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -251,7 +251,7 @@ RUN curl -sfSL --retry 5 https://raw.githubusercontent.com/ryuichiueda/opy/maste
     && chmod u+x /usr/local/bin/opy
 
 # base85
-RUN curl -sfSL --retry 5 https://github.com/redpeacock78/base85/releases/download/v0.0.8/base85-linux-x86 -o /usr/local/bin/base85 \
+RUN curl -sfSL --retry 5 https://github.com/redpeacock78/base85/releases/download/v0.0.11/base85-linux-x86 -o /usr/local/bin/base85 \
     && chmod u+x /usr/local/bin/base85
 
 # apt

--- a/Dockerfile
+++ b/Dockerfile
@@ -250,6 +250,10 @@ RUN curl -sfSL --retry 5 https://raw.githubusercontent.com/msr-i386/horizon/mast
 RUN curl -sfSL --retry 5 https://raw.githubusercontent.com/ryuichiueda/opy/master/opy -o /usr/local/bin/opy \
     && chmod u+x /usr/local/bin/opy
 
+# base85
+RUN curl -sfSL --retry 5 https://github.com/redpeacock78/base85/releases/download/v0.0.8/base85-linux-x86 -o /usr/local/bin/base85 \
+    && chmod u+x /usr/local/bin/base85
+
 # apt
 RUN --mount=type=bind,target=/var/lib/apt/lists,from=apt-cache,source=/var/lib/apt/lists \
     --mount=type=cache,target=/var/cache/apt \

--- a/docker_image.bats
+++ b/docker_image.bats
@@ -50,6 +50,11 @@
   [ "$status" -eq 0 ]
 }
 
+@test "base85" {
+  run bash -c 'echo "<~j+=c#Ju@X]X6>GN~>" | base85 -d'
+  [ "$output" = "シェル芸" ]
+}
+
 @test "bat" {
   run bat --version
   [[ "$output" =~ "bat " ]]


### PR DESCRIPTION
#164 対応

---

メモ）バイナリポンしてるけど、runtime を含むためか容量が 85MB 程度と結構大きいので、他の typescript 実装のコマンドも追加するなら、deno 自体を入れた方が良いかも。