### PR TITLE
fix: disable ke2daira on arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,6 +102,7 @@ RUN (cd /ocs/ocs; dotnet publish --configuration Release -p:PublishSingleFile=tr
 
 ## Rust
 FROM base AS rust-builder
+ARG TARGETARCH
 RUN --mount=type=bind,target=/var/lib/apt/lists,from=apt-cache,source=/var/lib/apt/lists \
     --mount=type=cache,target=/var/cache/apt,sharing=private \
     apt-get install -y -qq libmecab-dev mecab
@@ -111,7 +112,7 @@ RUN cargo install --git https://github.com/lotabout/rargs.git
 RUN cargo install --git https://github.com/KoharaKazuya/forest.git
 RUN cargo install --git https://github.com/o2sh/onefetch.git
 RUN cargo install --git https://github.com/greymd/teip.git
-RUN cargo install --git https://github.com/ryuichiueda/ke2daira.git
+RUN if [ "${TARGETARCH}" = "amd64" ]; then cargo install --git https://github.com/ryuichiueda/ke2daira.git; fi
 RUN find /root/.rustup /root/.cargo -type f \
     | grep -Ei 'license|readme' \
     | xargs -I@ echo "mkdir -p /tmp@; cp @ /tmp@" \

--- a/docker_image.bats
+++ b/docker_image.bats
@@ -462,6 +462,9 @@
 }
 
 @test "ke2daira" {
+  if [ "$(uname -m)" == "aarch64" ]; then
+    skip "ke2daira is not installed on aarch64"
+  fi
   run bash -c "echo シェル 芸 | ke2daira -m"
   [ "$output" = 'ゲェル シイ' ]
 }


### PR DESCRIPTION
#170 で arm64 でのビルドができなくなった件の対応