### PR TITLE
dotnetの更新でbatsが落ちるようになっちゃったので修正

### DIFF
--- a/docker_image.bats
+++ b/docker_image.bats
@@ -195,7 +195,7 @@
 
 @test "dotnet" {
   run dotnet --help
-  [ "${lines[3]}" = "Usage: dotnet [host-options] [path-to-application]" ]
+  [[ "${lines[1]}" =~ "Usage: dotnet" ]]
 }
 
 @test "eachdo" {


### PR DESCRIPTION
#172 に入れ忘れてしまいました

## コケちゃったビルド
https://app.circleci.com/pipelines/github/theoremoon/ShellgeiBot-Image/1070/workflows/65cea9f5-c3c9-4075-86bd-c0f7847461d2/jobs/1591/parallel-runs/0/steps/0-109

## ローカルで試したときのスクショ
![image](https://user-images.githubusercontent.com/15944290/156911405-eb90a037-44e7-4e1c-8257-2dfd4b0456f5.png)
