### PR TITLE
receiptio で png 出力を有効化

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,10 @@ RUN tar xf nodejs.tar.gz \
 ENV PATH $PATH:/usr/local/nodejs/bin
 RUN --mount=type=cache,target=/root/.npm \
     npm install -g --silent faker-cli chemi fx yukichant @amanoese/muscular kana2ipa receiptio
+# enable png output on receiptio
+RUN --mount=type=cache,target=/root/.npm \
+    if [ "${TARGETARCH}" = "amd64" ]; then npm install -g --silent puppeteer; fi \
+    && sed "s/puppeteer.launch({/& args: ['--no-sandbox'],/" -i /usr/local/nodejs/lib/node_modules/receiptio/lib/receiptio.js 
 
 ## .NET
 FROM base AS dotnet-builder


### PR DESCRIPTION
#178 の追加対応として、x86_64 環境で receiptio コマンドでの png 出力を有効化します。

receiptio はデフォルトでは SVG 形式で出力し、puppeteer がインストールされている場合は PNG で出力することもできます。
SVG から PNG の変換は ImageMagick の convert でも一応可能ですが、convert はフォントのスケールに対応していないようで、綺麗な画像が出力されなかったため、pupeteer 経由で Webブラウザでの綺麗な画像変換を利用しようと思います。

puppeteer は chrome/chromium に依存しますが、aarch 版の chromium が入手できないため、x86_64 版でのみインストールします。
root ユーザーで puppeteer を動作させる場合は引数に `--no-sandbox` が必要になりますが、receiptio ではそのような指定がなさそうだったため、ソースコードを直接上書きして対応することにしました。
