### PR TITLE
update: Ubuntu 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -177,17 +177,17 @@ COPY prefetched/mecab-ipadic/mecab-ipadic-2.7.0-20070801.tar.gz mecab-ipadic-neo
 RUN mkdir mecab-ipadic-neologd-utf8
 RUN mecab-ipadic-neologd/bin/install-mecab-ipadic-neologd -u -y -p /downloads/mecab-ipadic-neologd-utf8
 # bat
-RUN case $(uname -m) in \
-      x86_64)  curl -sfSL --retry 5 https://github.com/sharkdp/bat/releases/download/v0.20.0/bat_0.20.0_amd64.deb -o bat.deb ;; \
-      aarch64) curl -sfSL --retry 5 https://github.com/sharkdp/bat/releases/download/v0.20.0/bat_0.20.0_arm64.deb -o bat.deb ;; \
+RUN case ${TARGETARCH} in \
+      amd64) curl -sfSL --retry 5 https://github.com/sharkdp/bat/releases/download/v0.20.0/bat_0.20.0_amd64.deb -o bat.deb ;; \
+      arm64) curl -sfSL --retry 5 https://github.com/sharkdp/bat/releases/download/v0.20.0/bat_0.20.0_arm64.deb -o bat.deb ;; \
     esac
 # osquery
-RUN case $(uname -m) in \
-      x86_64)  curl -sfSL --retry 5 https://github.com/osquery/osquery/releases/download/5.2.2/osquery_5.2.2-1.linux_amd64.deb -o osquery.deb ;; \
-      aarch64) curl -sfSL --retry 5 https://github.com/osquery/osquery/releases/download/5.2.2/osquery_5.2.2-1.linux_arm64.deb -o osquery.deb ;; \
+RUN case ${TARGETARCH} in \
+      amd64) curl -sfSL --retry 5 https://github.com/osquery/osquery/releases/download/5.2.2/osquery_5.2.2-1.linux_amd64.deb -o osquery.deb ;; \
+      arm64) curl -sfSL --retry 5 https://github.com/osquery/osquery/releases/download/5.2.2/osquery_5.2.2-1.linux_arm64.deb -o osquery.deb ;; \
     esac
 # J
-RUN if [ "$(uname -m)" = "x86_64" ]; then \
+RUN if [ "${TARGETARCH}" = "amd64" ]; then \
       curl -sfSL --retry 5 http://www.jsoftware.com/download/j903/install/j903_linux64.tar.gz -o j.tar.gz; \
     fi
 
@@ -201,20 +201,20 @@ COPY prefetched/$TARGETARCH/openjdk.tar.gz .
 # Clojure
 RUN curl -sfSL --retry 5 https://download.clojure.org/install/linux-install-1.11.1.1105.sh -o clojure_install.sh
 # trdsql
-RUN case $(uname -m) in \
-      x86_64)  curl -sfSL --retry 5 https://github.com/noborus/trdsql/releases/download/v0.9.1/trdsql_v0.9.1_linux_amd64.zip -o trdsql.zip ;; \
-      aarch64) curl -sfSL --retry 5 https://github.com/noborus/trdsql/releases/download/v0.9.1/trdsql_v0.9.1_linux_arm64.zip -o trdsql.zip ;; \
+RUN case ${TARGETARCH} in \
+      amd64) curl -sfSL --retry 5 https://github.com/noborus/trdsql/releases/download/v0.9.1/trdsql_v0.9.1_linux_amd64.zip -o trdsql.zip ;; \
+      arm64) curl -sfSL --retry 5 https://github.com/noborus/trdsql/releases/download/v0.9.1/trdsql_v0.9.1_linux_arm64.zip -o trdsql.zip ;; \
     esac
 # PowerShell
 ENV POWERSHELL_VERSION 7.2.2
-RUN case $(uname -m) in \
-      x86_64)  curl -sfSL --retry 5 https://github.com/PowerShell/PowerShell/releases/download/v$POWERSHELL_VERSION/powershell-$POWERSHELL_VERSION-linux-x64.tar.gz   -o powershell.tar.gz ;; \
-      aarch64) curl -sfSL --retry 5 https://github.com/PowerShell/PowerShell/releases/download/v$POWERSHELL_VERSION/powershell-$POWERSHELL_VERSION-linux-arm64.tar.gz -o powershell.tar.gz ;; \
+RUN case ${TARGETARCH} in \
+      amd64) curl -sfSL --retry 5 https://github.com/PowerShell/PowerShell/releases/download/v$POWERSHELL_VERSION/powershell-$POWERSHELL_VERSION-linux-x64.tar.gz   -o powershell.tar.gz ;; \
+      arm64) curl -sfSL --retry 5 https://github.com/PowerShell/PowerShell/releases/download/v$POWERSHELL_VERSION/powershell-$POWERSHELL_VERSION-linux-arm64.tar.gz -o powershell.tar.gz ;; \
     esac
 # Chromium
 COPY prefetched/$TARGETARCH/chrome-linux.zip .
 # morsed (最新版のreleasesを取得するためjqで最新タグを取得)
-RUN if [ "$(uname -m)" = "x86_64" ]; then \
+RUN if [ "${TARGETARCH}" = "amd64" ]; then \
       curl -s https://api.github.com/repos/jiro4989/morsed/releases \
       | jq -r '.[0].assets[] | select(.name | test("morsed_linux.tar.gz")) | .browser_download_url' \
       | xargs curl -sfSLO --retry 5; \
@@ -224,6 +224,7 @@ WORKDIR /
 
 ## Runtime
 FROM base AS runtime
+ARG TARGETARCH
 
 # Set environments
 ENV LANG ja_JP.UTF-8
@@ -278,7 +279,7 @@ RUN curl -sfSL --retry 5 https://raw.githubusercontent.com/ryuichiueda/opy/maste
     && chmod u+x /usr/local/bin/opy
 
 # base85
-RUN if [ "$(uname -m)" = "x86_64" ]; then \
+RUN if [ "${TARGETARCH}" = "amd64" ]; then \
       curl -sfSL --retry 5 https://github.com/redpeacock78/base85/releases/download/v0.0.11/base85-linux-x86 -o /usr/local/bin/base85 \
       && chmod u+x /usr/local/bin/base85 ; \
     fi
@@ -429,9 +430,9 @@ COPY --from=general-builder /downloads/eki/bin /usr/local/bin
 
 # Egison
 RUN --mount=type=bind,target=/downloads,from=general-builder,source=/downloads \
-    case $(uname -m) in \
-      x86_64) dpkg -i /downloads/egison.deb ;; \
-      aarch64) mkdir /usr/lib/egison; tar xf /downloads/egison-*.tar.gz -C /usr/lib/egison --strip-components 1 ;; \
+    case ${TARGETARCH} in \
+      amd64) dpkg -i /downloads/egison.deb ;; \
+      arm64) mkdir /usr/lib/egison; tar xf /downloads/egison-*.tar.gz -C /usr/lib/egison --strip-components 1 ;; \
     esac
 ENV PATH $PATH:/usr/lib/egison/bin
 
@@ -456,7 +457,7 @@ RUN --mount=type=bind,target=/downloads,from=general-builder,source=/downloads \
 
 # J
 RUN --mount=type=bind,target=/downloads,from=general-builder,source=/downloads \
-    if [ "$(uname -m)" = "x86_64" ]; then \
+    if [ "${TARGETARCH}" = "amd64" ]; then \
       mkdir /usr/local/jsoftware \
       && tar xf /downloads/j.tar.gz -C /usr/local/jsoftware --strip-components 1; \
     fi
@@ -473,7 +474,7 @@ RUN --mount=type=bind,target=/downloads,from=general-builder,source=/downloads \
     && unzip /downloads/trdsql.zip -d /usr/local \
     && ln -s /usr/local/trdsql_v0.9.1_linux_*/trdsql /usr/local/bin \
     && /bin/bash /downloads/clojure_install.sh \
-    && if [ "$(uname -m)" = "x86_64" ]; then unzip /downloads/chrome-linux.zip -d /usr/local; fi
+    && if [ "${TARGETARCH}" = "amd64" ]; then unzip /downloads/chrome-linux.zip -d /usr/local; fi
 
 ENV JAVA_HOME /usr/local/jdk-18.0.1
 ENV PATH $PATH:/usr/local/julia-1.6.6/bin:$JAVA_HOME/bin:/usr/local/chrome-linux
@@ -490,7 +491,7 @@ RUN --mount=type=bind,target=/downloads,from=general-builder,source=/downloads \
 
 # morsed
 RUN --mount=type=bind,target=/downloads,from=general-builder,source=/downloads \
-    if [ "$(uname -m)" = "x86_64" ]; then \
+    if [ "${TARGETARCH}" = "amd64" ]; then \
       tar xf /downloads/morsed_linux.tar.gz -C /usr/local/ \
       && ln -s /usr/local/morsed_linux/morsed /usr/local/bin/; \
     fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -188,9 +188,9 @@ RUN case $(uname -m) in \
       aarch64) curl -sfSL --retry 5 https://github.com/osquery/osquery/releases/download/5.2.2/osquery_5.2.2-1.linux_arm64.deb -o osquery.deb ;; \
     esac
 # J
-RUN case $(uname -m) in \
-      x86_64)  curl -sfSL --retry 5 https://www.jsoftware.com/download/j903/install/j903_amd64.deb -o j.deb ;; \
-    esac
+RUN if [ "$(uname -m)" = "x86_64" ]; then \
+      curl -sfSL --retry 5 http://www.jsoftware.com/download/j903/install/j903_linux64.tar.gz -o j.tar.gz; \
+    fi
 
 # Egison
 COPY egison/egison-linux-${TARGETARCH}.tar.gz .
@@ -454,10 +454,17 @@ RUN --mount=type=bind,target=/downloads,from=general-builder,source=/downloads \
     && /downloads/super_unko/install.sh \
     && /downloads/echo-meme/install.sh
 
-# bat, osquery, J
+# J
 RUN --mount=type=bind,target=/downloads,from=general-builder,source=/downloads \
-    dpkg --install /downloads/bat.deb /downloads/osquery.deb \
-    && if [ "$(uname -m)" = "x86_64" ]; then dpkg --install /downloads/j.deb; fi
+    if [ "$(uname -m)" = "x86_64" ]; then \
+      mkdir /usr/local/jsoftware \
+      && tar xf /downloads/j.tar.gz -C /usr/local/jsoftware --strip-components 1; \
+    fi
+ENV PATH $PATH:/usr/local/jsoftware/bin
+
+# bat, osquery
+RUN --mount=type=bind,target=/downloads,from=general-builder,source=/downloads \
+    dpkg --install /downloads/bat.deb /downloads/osquery.deb
 
 # Julia, OpenJDK, trdsql (apply sql to csv), Clojure, chromium
 RUN --mount=type=bind,target=/downloads,from=general-builder,source=/downloads \

--- a/docker_image.bats
+++ b/docker_image.bats
@@ -51,9 +51,7 @@
 }
 
 @test "base85" {
-  if [ "$(uname -m)" == "aarch64" ]; then
-    skip "don't install base85 on aarch64"
-  fi
+  if [ "$(uname -m)" = "aarch64" ]; then skip "base85 is not installed on aarch64"; fi
   run bash -c 'echo "<~j+=c#Ju@X]X6>GN~>" | base85 -d'
   [ "$output" = "シェル芸" ]
 }
@@ -114,9 +112,7 @@
 }
 
 @test "chromium" {
-  if [ "$(uname -m)" == "aarch64" ]; then
-    skip "don't install chromium on aarch64"
-  fi
+  if [ "$(uname -m)" = "aarch64" ]; then skip "chromium is not installed on aarch64"; fi
   run chrome --version
   [[ "$output" =~ "Chromium" ]]
 }
@@ -199,6 +195,7 @@
 }
 
 @test "eachdo" {
+  if [ "$(uname -m)" = "aarch64" ]; then skip "eachdo is not installed on aarch64"; fi
   run eachdo -v
   [[ "$output" =~ "eachdo command" ]]
 }
@@ -209,6 +206,7 @@
 }
 
 @test "edens" {
+  if [ "$(uname -m)" = "aarch64" ]; then skip "edens is not installed on aarch64"; fi
   run edens -h
   [ "$status" -eq 0 ]
 }
@@ -361,6 +359,7 @@
 }
 
 @test "gyaric" {
+  if [ "$(uname -m)" = "aarch64" ]; then skip "gyaric is not installed on aarch64"; fi
   run gyaric -h
   [ "${lines[0]}" = "gyaric encode/decode a text to unreadable gyaru's text." ]
 }
@@ -419,10 +418,8 @@
 }
 
 @test "J" {
-  if [ "$(uname -m)" = "aarch64" ]; then
-    skip "don't install Jlang on aarch64"
-  fi
-  run bash -c "echo \"'シェル芸'\" | ijconsole"
+  if [ "$(uname -m)" = "aarch64" ]; then skip "J is not installed on aarch64"; fi
+  run bash -c "echo \"'シェル芸'\" | jconsole"
   [ "${lines[0]}" = 'シェル芸' ]
 }
 
@@ -457,9 +454,7 @@
 }
 
 @test "ke2daira" {
-  if [ "$(uname -m)" == "aarch64" ]; then
-    skip "ke2daira is not installed on aarch64"
-  fi
+  if [ "$(uname -m)" = "aarch64" ]; then skip "ke2daira is not installed on aarch64"; fi
   run bash -c "echo シェル 芸 | ke2daira -m"
   [ "$output" = 'ゲェル シイ' ]
 }
@@ -521,6 +516,7 @@
 }
 
 @test "maze" {
+  if [ "$(uname -m)" = "aarch64" ]; then skip "maze is not installed on aarch64"; fi
   run maze -h
   [ "$status" -eq 0 ]
 
@@ -547,9 +543,7 @@
 }
 
 @test "morsed" {
-  if [ "$(uname -m)" == "aarch64" ]; then
-    skip "don't install morsed on aarch64"
-  fi
+  if [ "$(uname -m)" = "aarch64" ]; then skip "morsed is not installed on aarch64"; fi
   run bash -c "morsed -p 名詞 -s 寿司 吾輩は猫である"
   [ "$output" = "寿司は寿司である" ]
 }
@@ -581,6 +575,7 @@
 }
 
 @test "nim" {
+  if [ "$(uname -m)" = "aarch64" ]; then skip "nim is not installed on aarch64"; fi
   run nim --help
   [[ "${lines[0]}" =~ 'Nim Compiler' ]]
 }
@@ -802,6 +797,7 @@
 }
 
 @test "rect" {
+  if [ "$(uname -m)" = "aarch64" ]; then skip "rect is not installed on aarch64"; fi
   run rect --help
   [ "${lines[0]}" = 'rect is a command to crop/paste rectangle text' ]
 }

--- a/docker_image.bats
+++ b/docker_image.bats
@@ -270,11 +270,6 @@
   [ "${lines[4]}" = "|____/|_| |_|\___|_|_|\____|\___|_|" ]
 }
 
-@test "firefox" {
-  run firefox --version
-  [[ "$output" =~ "Mozilla Firefox" ]]
-}
-
 @test "fish" {
   run fish -c "echo シェル芸"
   [ "$output" = "シェル芸" ]
@@ -660,7 +655,7 @@
   [ "$output" = 'シ ェ ル 芸' ]
 }
 
-@test "openjdk11" {
+@test "openjdk" {
   run javac -version
   [[ "$output" =~ "javac " ]]
 }

--- a/egison/Dockerfile
+++ b/egison/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:21.10 AS apt-cache
+FROM ubuntu:22.04 AS apt-cache
 RUN apt-get update
 
-FROM ubuntu:21.10 AS base
+FROM ubuntu:22.04 AS base
 ENV DEBIAN_FRONTEND noninteractive
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; \
     echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache

--- a/prefetch_files.sh
+++ b/prefetch_files.sh
@@ -22,20 +22,20 @@ download() {
 }
 
 # go
-if [ "$arch" = "amd64" ]; then download https://dl.google.com/go/go1.17.2.linux-amd64.tar.gz go.tar.gz; fi
-if [ "$arch" = "arm64" ]; then download https://dl.google.com/go/go1.17.2.linux-arm64.tar.gz go.tar.gz; fi
+if [ "$arch" = "amd64" ]; then download https://dl.google.com/go/go1.18.1.linux-amd64.tar.gz go.tar.gz; fi
+if [ "$arch" = "arm64" ]; then download https://dl.google.com/go/go1.18.1.linux-arm64.tar.gz go.tar.gz; fi
 
 # chromium (x64 only)
 if [ "$arch" = "amd64" ]; then download "https://download-chromium.appspot.com/dl/Linux_x64?type=snapshots" chrome-linux.zip; fi
 if [ "$arch" = "arm64" ]; then touch "$DOWNLOAD_DIR/$arch/chrome-linux.zip" ; fi  # dummy
 
 # julia
-if [ "$arch" = "amd64" ]; then download https://julialang-s3.julialang.org/bin/linux/x64/1.6/julia-1.6.3-linux-x86_64.tar.gz      julia.tar.gz; fi
-if [ "$arch" = "arm64" ]; then download https://julialang-s3.julialang.org/bin/linux/aarch64/1.6/julia-1.6.3-linux-aarch64.tar.gz julia.tar.gz; fi
+if [ "$arch" = "amd64" ]; then download https://julialang-s3.julialang.org/bin/linux/x64/1.6/julia-1.6.6-linux-x86_64.tar.gz      julia.tar.gz; fi
+if [ "$arch" = "arm64" ]; then download https://julialang-s3.julialang.org/bin/linux/aarch64/1.6/julia-1.6.6-linux-aarch64.tar.gz julia.tar.gz; fi
 
 # openjdk
-if [ "$arch" = "amd64" ]; then download https://download.java.net/java/GA/jdk17/0d483333a00540d886896bac774ff48b/35/GPL/openjdk-17_linux-x64_bin.tar.gz     openjdk.tar.gz; fi
-if [ "$arch" = "arm64" ]; then download https://download.java.net/java/GA/jdk17/0d483333a00540d886896bac774ff48b/35/GPL/openjdk-17_linux-aarch64_bin.tar.gz openjdk.tar.gz; fi
+if [ "$arch" = "amd64" ]; then download https://download.java.net/java/GA/jdk18.0.1/3f48cabb83014f9fab465e280ccf630b/10/GPL/openjdk-18.0.1_linux-x64_bin.tar.gz     openjdk.tar.gz; fi
+if [ "$arch" = "arm64" ]; then download https://download.java.net/java/GA/jdk18.0.1/3f48cabb83014f9fab465e280ccf630b/10/GPL/openjdk-18.0.1_linux-aarch64_bin.tar.gz openjdk.tar.gz; fi
 
 # nodejs
 node_version="$(curl -s https://nodejs.org/dist/index.json | jq -r '[.[]|select(.lts)][0].version')"


### PR DESCRIPTION
- Ruby 3.0 が入るため、matsuya のバージョン固定を解除
    - Find Pattern は Ruby 3.0 では experimental のため警告が出るが、許容
    - Ruby 3.1 になれば experimental が外れるはず
- Ubuntu 21.10 は OpenSSL v1.1.1 が入っていたが、Ubuntu 22.04 では OpenSSL v3.0.2 にアップデートされた
    - Nim の OpenSSL ラッパーは現時点で OpenSSL 3 に未対応のためか、apt リポジトリから削除されている
    - ~~公式で配布されているバイナリは静的リンクされており、x64版がなぜかArm64でも動作するようだったので、これで代替~~ 代替できてない、要対応
- Firefox が snap 版になったため削除
- その他のツールも最新版にアップデート

（arm64 版のみ手元で動作確認したので、x64版はCircleCIのぱわーを借りる）