### PR TITLE
fix: teip test

### DIFF
--- a/docker_image.bats
+++ b/docker_image.bats
@@ -986,8 +986,8 @@
 }
 
 @test "teip" {
-  run teip --help
-  [ "${lines[1]}" = "Allow the command handle selected parts of the standard input, and bypass other parts." ]
+  run teip -f2 -- sed 's/.*/芸/' <<< "シェル ゲイ"
+  [ "$output" = "シェル 芸" ]
 }
 
 @test "telnet" {


### PR DESCRIPTION
teip v2 で help メッセージが変わったため、テストケースを help メッセージに依存しない方法に修正