### PR TITLE
新しいバージョンのbatsがはいるようにして、--print-output-on-failure する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ RUN tar xf nodejs.tar.gz \
     && mv node-* /usr/local/nodejs
 ENV PATH $PATH:/usr/local/nodejs/bin
 RUN --mount=type=cache,target=/root/.npm \
-    npm install -g --silent faker-cli chemi fx yukichant @amanoese/muscular kana2ipa receiptio
+    npm install -g --silent faker-cli chemi fx yukichant @amanoese/muscular kana2ipa receiptio bats
 # enable png output on receiptio
 RUN --mount=type=cache,target=/root/.npm \
     if [ "${TARGETARCH}" = "amd64" ]; then npm install -g --silent puppeteer; fi \
@@ -291,7 +291,6 @@ RUN --mount=type=bind,target=/var/lib/apt/lists,from=apt-cache,source=/var/lib/a
      agrep \
      apache2-utils \
      ash yash \
-     bats \
      bbe \
      bc \
      bf \

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ test-ci:
 		--net none \
 		-v $(CURDIR):/root/src \
 		$(DOCKER_IMAGE_NAME) \
-		/bin/bash -c "bats --tap /root/src/docker_image.bats"
+		/bin/bash -c "bats --print-output-on-failure --tap /root/src/docker_image.bats"
 
 clean: $(subdirs)
 	rm -f *.log


### PR DESCRIPTION
- テストが落ちているときにどういう感じでおちているのかわからない
  - 修正するときに何が起きているかわからないがちで不便
- bats 1.5.0 からは `--print-output-on-failure` というオプションが追加されているのでこれを使って、CircleCIとかからみて何が悪いのかわかりやすくしたい


apt repositoryにおいてあったbatsは1.2とかだったので1.5.0以降がはいるようにnpmでインストールするようにしてみました