### PR TITLE
Open-usp-Tukubai 由来の uconv をインストールしない

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -142,8 +142,9 @@ RUN --mount=type=bind,target=/var/lib/apt/lists,from=apt-cache,source=/var/lib/a
     --mount=type=cache,target=/var/cache/apt,sharing=private \
     apt-get install -y -qq file jq libncursesw5-dev libmecab-dev mecab
 WORKDIR /downloads
-# Open-usp-Tukubai
-RUN git clone --depth 1 https://github.com/usp-engineers-community/Open-usp-Tukubai.git
+# Open-usp-Tukubai; uconv は icu-devtools パッケージで入るため、Open-usp-Tukubai の uconv はインストールしない
+RUN git clone --depth 1 https://github.com/usp-engineers-community/Open-usp-Tukubai.git \
+    && sed -E 's/uconv[\.txt|\.html]?//' -i ./Open-usp-Tukubai/Makefile
 # edfsay
 RUN git clone --depth 1 https://github.com/jiro4989/edfsay.git
 # color, rainbow


### PR DESCRIPTION
## 経緯

- Open-usp-Tukubai に [uconv コマンドが追加された](https://github.com/usp-engineers-community/Open-usp-Tukubai/commit/07068005323de0273d62349d8a87a743e1d213b8)
- 元々 icu-devtools パッケージで入る uconv と名前が衝突し、`PATH` では `/usr/local/bin` が優先されるため、icu-devtools 由来の uconv 前提の[テストがこけるようになった](https://app.circleci.com/pipelines/github/theoremoon/ShellgeiBot-Image/1266/workflows/1ce6076c-d517-4b7e-9cda-d0e41f47ed3e/jobs/2235?invite=true#step-109-185)

```sh
$ which -a uconv
/usr/local/bin/uconv     # Open-usp-Tukubai 由来
/usr/bin/uconv           # icu-devtools 由来
/bin/uconv               # /usr/bin/uconv へのシンボリックリンク
```

## 方針

- icu-devtools の uconv を優先したい
- `PATH` での優先順序は（副作用が結構ありそうなので）あまり変更したくない
- Open-usp-Tukubai の Makefile をアドホックに修正して uconv をインストールしないようにする