### PR TITLE
Onefetch のバージョンを固定する

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -114,7 +114,7 @@ RUN curl -sfSL --retry 5 https://sh.rustup.rs | sh -s -- -y
 ENV PATH $PATH:/root/.cargo/bin
 RUN cargo install --git https://github.com/lotabout/rargs.git
 RUN cargo install --git https://github.com/KoharaKazuya/forest.git
-RUN cargo install --git https://github.com/o2sh/onefetch.git
+RUN cargo install --git https://github.com/o2sh/onefetch.git --tag v2.12.0
 RUN cargo install --git https://github.com/greymd/teip.git
 RUN cargo install --git https://github.com/xztaityozx/surge.git
 RUN if [ "${TARGETARCH}" = "amd64" ]; then cargo install --git https://github.com/ryuichiueda/ke2daira.git; fi


### PR DESCRIPTION
しばらくイメージのビルドがこけている。
o2sh/onefetch が依存する git-repository v0.20.0 がビルドできていない。
Onefetch の main ブランチではなく、タグを指定してビルドを安定させる。

---

元々は [GitHub の Release からビルド済みのバイナリをインストールしていた](https://github.com/theoremoon/ShellgeiBot-Image/commit/a0e386ad8e4ddb7154ed1d63c37214b67235d5ab#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L185)が、Arm64 対応のために Git リポジトリからソースを取得してビルドするように変更した。
その際にタグの指定を忘れた。ごめんなさいね。