### PR TITLE
revert: longcat

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN --mount=type=cache,target=/root/go/pkg --mount=type=cache,target=/root/.cach
 RUN --mount=type=cache,target=/root/go/pkg --mount=type=cache,target=/root/.cache/go-build go install github.com/jiro4989/textchat@latest
 RUN --mount=type=cache,target=/root/go/pkg --mount=type=cache,target=/root/.cache/go-build go install github.com/jiro4989/textimg/v3@latest
 RUN --mount=type=cache,target=/root/go/pkg --mount=type=cache,target=/root/.cache/go-build go install github.com/jmhobbs/terminal-parrot@latest
-# RUN --mount=type=cache,target=/root/go/pkg --mount=type=cache,target=/root/.cache/go-build go install github.com/mattn/longcat@latest
+RUN --mount=type=cache,target=/root/go/pkg --mount=type=cache,target=/root/.cache/go-build go install github.com/mattn/longcat@latest
 RUN --mount=type=cache,target=/root/go/pkg --mount=type=cache,target=/root/.cache/go-build go install github.com/ryuichiueda/kkcw@latest
 RUN --mount=type=cache,target=/root/go/pkg --mount=type=cache,target=/root/.cache/go-build go install github.com/sugyan/ttyrec2gif@latest
 RUN --mount=type=cache,target=/root/go/pkg --mount=type=cache,target=/root/.cache/go-build go install github.com/tomnomnom/gron@latest

--- a/docker_image.bats
+++ b/docker_image.bats
@@ -477,10 +477,10 @@ bats_require_minimum_version 1.5.0
   [[ "${lines[0]}" =~ "lolcat" ]]
 }
 
-# @test "longcat" {
-#   run -0 longcat -i 4 -o /a.png
-#   [ -f /a.png ]
-# }
+@test "longcat" {
+  run -0 longcat -i 4 -o /a.png
+  [ -f /a.png ]
+}
 
 @test "lua" {
   run -0 lua -e 'print("シェル芸")'


### PR DESCRIPTION
longcat が v0.0.4 までリリースされており、正常にインストールできるようになっているため、#184 の対応を元に戻します。