### PR TITLE
Puppeteer のインストール時に Chromium をインストールしない

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -81,8 +81,8 @@ RUN --mount=type=cache,target=/root/.npm \
     npm install -g --silent faker-cli chemi fx yukichant @amanoese/muscular kana2ipa receiptio bats
 # enable png output on receiptio
 RUN --mount=type=cache,target=/root/.npm \
-    if [ "${TARGETARCH}" = "amd64" ]; then npm install -g --silent puppeteer; fi \
-    && sed "s/puppeteer.launch({/& args: ['--no-sandbox'],/" -i /usr/local/nodejs/lib/node_modules/receiptio/lib/receiptio.js 
+    if [ "${TARGETARCH}" = "amd64" ]; then PUPPETEER_SKIP_DOWNLOAD=true npm install -g --silent puppeteer; fi \
+    && sed "s/puppeteer.launch({/& args: ['--no-sandbox'],/" -i /usr/local/nodejs/lib/node_modules/receiptio/lib/receiptio.js
 
 ## .NET
 FROM base AS dotnet-builder
@@ -475,6 +475,7 @@ RUN --mount=type=bind,target=/downloads,from=general-builder,source=/downloads \
     && ln -s /usr/local/trdsql_v0.9.1_linux_*/trdsql /usr/local/bin \
     && /bin/bash /downloads/clojure_install.sh \
     && if [ "${TARGETARCH}" = "amd64" ]; then unzip /downloads/chrome-linux.zip -d /usr/local; fi
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/local/chrome-linux/chrome
 
 ENV JAVA_HOME /usr/local/jdk-18.0.1
 ENV PATH $PATH:/usr/local/julia-1.6.6/bin:$JAVA_HOME/bin:/usr/local/chrome-linux


### PR DESCRIPTION
## 事象
- 10/15 から定時ビルドがこけるようになった
    - https://app.circleci.com/pipelines/github/theoremoon/ShellgeiBot-Image/1343/workflows/78e39285-2932-4a87-83c6-0292ccc705c6/jobs/2505?invite=true#step-106-1268

<details>

```sh
# npm install -g puppeteer
npm ERR! code 1
npm ERR! path /usr/local/nodejs/lib/node_modules/puppeteer
npm ERR! command failed
npm ERR! command sh -c -- node install.js
npm ERR! ERROR: Failed to set up Chromium r1045629! Set "PUPPETEER_SKIP_DOWNLOAD" env variable to skip download.
npm ERR! [Error: EACCES: permission denied, mkdir '/root/.cache/puppeteer/chrome'] {
npm ERR!   errno: -13,
npm ERR!   code: 'EACCES',
npm ERR!   syscall: 'mkdir',
npm ERR!   path: '/root/.cache/puppeteer/chrome'
npm ERR! }

npm ERR! A complete log of this run can be found in:
npm ERR!     /root/.npm/_logs/2022-10-16T07_02_06_481Z-debug-0.log
```

</details>

- Puppeteer と一緒に入る Chromium のインストール時にディレクトリが作成できずにこけている模様

## 対応方針

- Chromium は Puppeteer とは別にインストールしているため、 `PUPPETEER_SKIP_DOWNLOAD=true` を指定して Chromium のインストールをスキップし、別途 `PUPPETEER_EXECUTABLE_PATH` に Chromium のパスを指定して Puppeteer が Chromium を呼び出せるようにしておく