### PR TITLE
fix: Puppeteer installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,9 +79,9 @@ RUN tar xf nodejs.tar.gz \
 ENV PATH $PATH:/usr/local/nodejs/bin
 RUN --mount=type=cache,target=/root/.npm \
     npm install -g --silent faker-cli chemi fx yukichant @amanoese/muscular kana2ipa receiptio bats
-# enable png output on receiptio
+# enable png output on receiptio; do not install chromium here
 RUN --mount=type=cache,target=/root/.npm \
-    if [ "${TARGETARCH}" = "amd64" ]; then PUPPETEER_SKIP_DOWNLOAD=true npm install -g --silent puppeteer; fi \
+    if [ "${TARGETARCH}" = "amd64" ]; then npm install -g puppeteer --ignore-scripts; fi \
     && sed "s/puppeteer.launch({/& args: ['--no-sandbox'],/" -i /usr/local/nodejs/lib/node_modules/receiptio/lib/receiptio.js
 
 ## .NET


### PR DESCRIPTION
- PullReq #192 で Puppeteer [v19.0.0](https://github.com/puppeteer/puppeteer/releases/tag/v19.0.0) での変更に対処するため `PUPPETEER_SKIP_DOWNLOAD=true` を設定し、Chromium をインストールしないようにしたが、10/22 から再度[ビルドがこける](https://app.circleci.com/pipelines/github/theoremoon/ShellgeiBot-Image/1351/workflows/cbe0cbbc-2337-4e55-b056-8eca995da853/jobs/2531)ようになってしまった
- npm install に `--ignore-scripts` を設定し、npm で postscript が実行されないように対処する
    - 参考：https://github.com/puppeteer/puppeteer/issues/6492
    - ついでに：インストールがこけたときにエラーメッセージが出てほしいので、`--silent` を外しておく