### PR TITLE
Ubuntu 22.10 対応

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,10 @@ version: 2.1
 executors:
   builder:
     machine:
-      image: ubuntu-2004:202111-02  # https://circleci.com/docs/2.0/configuration-reference/#available-machine-images
+      image: ubuntu-2204:2022.10.1  # https://circleci.com/docs/configuration-reference/#available-linux-machine-images-cloud
   deployer:
     docker:
-      - image: cimg/base:2021.12-20.04  # https://circleci.com/docs/2.0/next-gen-migration-guide/
+      - image: cimg/base:2022.10-22.04  # https://circleci.com/developer/ja/images/image/cimg/base
 
 commands:
   build-image:
@@ -71,14 +71,14 @@ jobs:
     environment:
       DOCKER_BUILDKIT: '1'
       DOCKER_IMAGE_NAME: theoldmoon0602/shellgeibot
-    resource_class: large  # 4vCPU, 8GB RAM; https://circleci.com/docs/ja/2.0/configuration-reference/#resourceclass
+    resource_class: large  # 4vCPU, 15GB RAM; https://circleci.com/docs/ja/2.0/configuration-reference/#resourceclass
     steps:
       - build-image:
           arch: amd64
 
   build-arm64:
     executor: builder
-    resource_class: arm.medium  # 2vCPU, 8GB RAM; https://circleci.com/docs/ja/2.0/arm-resources/
+    resource_class: arm.large  # 4vCPU, 16GB RAM; https://circleci.com/docs/ja/2.0/arm-resources/
     environment:
       DOCKER_BUILDKIT: '1'
       DOCKER_IMAGE_NAME: theoldmoon0602/shellgeibot

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # syntax = docker/dockerfile:latest
-FROM ubuntu:22.04 AS apt-cache
+FROM ubuntu:22.10 AS apt-cache
 RUN apt-get update
 
-FROM ubuntu:22.04 AS base
+FROM ubuntu:22.10 AS base
 ENV DEBIAN_FRONTEND noninteractive
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; \
     echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
@@ -85,13 +85,13 @@ FROM base AS dotnet-builder
 ARG TARGETARCH
 RUN --mount=type=bind,target=/var/lib/apt/lists,from=apt-cache,source=/var/lib/apt/lists \
     --mount=type=cache,target=/var/cache/apt,sharing=private \
-    apt-get install -y -qq libc6 libgcc-s1 libgssapi-krb5-2 libicu70 libssl3 libstdc++6 zlib1g
+    apt-get install -y -qq libc6 libgcc-s1 libgssapi-krb5-2 libicu71 libssl3 libstdc++6 zlib1g
 
 # https://docs.microsoft.com/ja-jp/dotnet/core/tools/dotnet-install-script
 ADD https://dot.net/v1/dotnet-install.sh dotnet-install.sh
-# Runtime: 6.0.4, SDK: 6.0.202; https://dotnet.microsoft.com/en-us/download/dotnet/6.0
-RUN bash dotnet-install.sh --version 6.0.4 --runtime dotnet --install-dir /usr/local/dotnet
-RUN bash dotnet-install.sh --version 6.0.202
+# Runtime: 6.0.10, SDK: 6.0.402; https://dotnet.microsoft.com/en-us/download/dotnet/6.0
+RUN bash dotnet-install.sh --version 6.0.10 --runtime dotnet --install-dir /usr/local/dotnet
+RUN bash dotnet-install.sh --version 6.0.402
 ENV PATH $PATH:/root/.dotnet
 # noc
 RUN git clone --depth 1 https://github.com/xztaityozx/noc.git
@@ -125,7 +125,7 @@ FROM base AS nim-builder
 ARG TARGETARCH
 RUN mkdir nim \
     && if [ "${TARGETARCH}" = "amd64" ]; then \
-      curl -sfSL --retry 5 https://nim-lang.org/download/nim-1.6.4-linux_x64.tar.xz -o nim.tar.xz \
+      curl -sfSL --retry 5 https://nim-lang.org/download/nim-1.6.8-linux_x64.tar.xz -o nim.tar.xz \
       && tar xf nim.tar.xz --strip-components 1 -C nim \
       && (cd nim/; ./install.sh /usr/local/bin && cp ./bin/nimble /usr/local/bin/) \
     fi
@@ -175,13 +175,13 @@ RUN mkdir mecab-ipadic-neologd-utf8
 RUN mecab-ipadic-neologd/bin/install-mecab-ipadic-neologd -u -y -p /downloads/mecab-ipadic-neologd-utf8
 # bat
 RUN case ${TARGETARCH} in \
-      amd64) curl -sfSL --retry 5 https://github.com/sharkdp/bat/releases/download/v0.20.0/bat_0.20.0_amd64.deb -o bat.deb ;; \
-      arm64) curl -sfSL --retry 5 https://github.com/sharkdp/bat/releases/download/v0.20.0/bat_0.20.0_arm64.deb -o bat.deb ;; \
+      amd64) curl -sfSL --retry 5 https://github.com/sharkdp/bat/releases/download/v0.22.1/bat_0.22.1_amd64.deb -o bat.deb ;; \
+      arm64) curl -sfSL --retry 5 https://github.com/sharkdp/bat/releases/download/v0.22.1/bat_0.22.1_arm64.deb -o bat.deb ;; \
     esac
 # osquery
 RUN case ${TARGETARCH} in \
-      amd64) curl -sfSL --retry 5 https://github.com/osquery/osquery/releases/download/5.2.2/osquery_5.2.2-1.linux_amd64.deb -o osquery.deb ;; \
-      arm64) curl -sfSL --retry 5 https://github.com/osquery/osquery/releases/download/5.2.2/osquery_5.2.2-1.linux_arm64.deb -o osquery.deb ;; \
+      amd64) curl -sfSL --retry 5 https://github.com/osquery/osquery/releases/download/5.5.1/osquery_5.5.1-1.linux_amd64.deb -o osquery.deb ;; \
+      arm64) curl -sfSL --retry 5 https://github.com/osquery/osquery/releases/download/5.5.1/osquery_5.5.1-1.linux_arm64.deb -o osquery.deb ;; \
     esac
 # J
 RUN if [ "${TARGETARCH}" = "amd64" ]; then \
@@ -199,11 +199,11 @@ COPY prefetched/$TARGETARCH/openjdk.tar.gz .
 RUN curl -sfSL --retry 5 https://download.clojure.org/install/linux-install-1.11.1.1105.sh -o clojure_install.sh
 # trdsql
 RUN case ${TARGETARCH} in \
-      amd64) curl -sfSL --retry 5 https://github.com/noborus/trdsql/releases/download/v0.9.1/trdsql_v0.9.1_linux_amd64.zip -o trdsql.zip ;; \
-      arm64) curl -sfSL --retry 5 https://github.com/noborus/trdsql/releases/download/v0.9.1/trdsql_v0.9.1_linux_arm64.zip -o trdsql.zip ;; \
+      amd64) curl -sfSL --retry 5 https://github.com/noborus/trdsql/releases/download/v0.10.0/trdsql_v0.10.0_linux_amd64.zip -o trdsql.zip ;; \
+      arm64) curl -sfSL --retry 5 https://github.com/noborus/trdsql/releases/download/v0.10.0/trdsql_v0.10.0_linux_arm64.zip -o trdsql.zip ;; \
     esac
 # PowerShell
-ENV POWERSHELL_VERSION 7.2.2
+ENV POWERSHELL_VERSION 7.2.7
 RUN case ${TARGETARCH} in \
       amd64) curl -sfSL --retry 5 https://github.com/PowerShell/PowerShell/releases/download/v$POWERSHELL_VERSION/powershell-$POWERSHELL_VERSION-linux-x64.tar.gz   -o powershell.tar.gz ;; \
       arm64) curl -sfSL --retry 5 https://github.com/PowerShell/PowerShell/releases/download/v$POWERSHELL_VERSION/powershell-$POWERSHELL_VERSION-linux-arm64.tar.gz -o powershell.tar.gz ;; \
@@ -363,6 +363,7 @@ RUN --mount=type=bind,target=/var/lib/apt/lists,from=apt-cache,source=/var/lib/a
      w3m nginx \
      whiptail \
      xvfb xterm x11-apps xdotool \
+     xxd \
      zsh
 
 # kagome
@@ -466,11 +467,11 @@ RUN --mount=type=bind,target=/downloads,from=general-builder,source=/downloads \
     tar xf /downloads/julia.tar.gz -C /usr/local \
     && tar xf /downloads/openjdk.tar.gz -C /usr/local \
     && unzip /downloads/trdsql.zip -d /usr/local \
-    && ln -s /usr/local/trdsql_v0.9.1_linux_*/trdsql /usr/local/bin \
+    && ln -s /usr/local/trdsql_v0.10.0_linux_*/trdsql /usr/local/bin \
     && /bin/bash /downloads/clojure_install.sh
 
-ENV JAVA_HOME /usr/local/jdk-18.0.1
-ENV PATH $PATH:/usr/local/julia-1.6.6/bin:$JAVA_HOME/bin
+ENV JAVA_HOME /usr/local/jdk-19.0.1
+ENV PATH $PATH:/usr/local/julia-1.8.2/bin:$JAVA_HOME/bin
 # Clojure が実行時に必要とするパッケージを取得
 RUN clojure -e '(println "test")'
 # Clojure ワンライナー
@@ -494,7 +495,7 @@ RUN mv /usr/bin/man.REAL /usr/bin/man
 
 # reset apt config
 RUN rm /etc/apt/apt.conf.d/keep-cache /etc/apt/apt.conf.d/no-install-recommends
-COPY --from=ubuntu:22.04 /etc/apt/apt.conf.d/docker-clean /etc/apt/apt.conf.d/
+COPY --from=ubuntu:22.10 /etc/apt/apt.conf.d/docker-clean /etc/apt/apt.conf.d/
 
 # ShellgeiBot-Image information
 RUN mkdir -p /etc/shellgeibot-image

--- a/docker_image.bats
+++ b/docker_image.bats
@@ -932,8 +932,8 @@ bats_require_minimum_version 1.5.0
 }
 
 @test "telnet" {
-  run -1 telnet -h
-  [ "${lines[0]}" = "telnet: invalid option -- 'h'" ]
+  run -0 telnet --help
+  [ "${lines[0]}" = "Usage: telnet [OPTION...] [HOST [PORT]]" ]
 }
 
 @test "terminal-parrot" {

--- a/egison/Dockerfile
+++ b/egison/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:22.10 AS apt-cache
+FROM ubuntu:22.04 AS apt-cache
 RUN apt-get update
 
-FROM ubuntu:22.10 AS base
+FROM ubuntu:22.04 AS base
 ENV DEBIAN_FRONTEND noninteractive
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; \
     echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
@@ -14,4 +14,3 @@ FROM base AS builder
 RUN --mount=type=bind,target=/var/lib/apt/lists,from=apt-cache,source=/var/lib/apt/lists \
     --mount=type=cache,target=/var/cache/apt \
     apt-get install -y -qq haskell-platform
-COPY build.sh /

--- a/egison/Dockerfile
+++ b/egison/Dockerfile
@@ -1,7 +1,7 @@
-FROM ubuntu:22.04 AS apt-cache
+FROM ubuntu:22.10 AS apt-cache
 RUN apt-get update
 
-FROM ubuntu:22.04 AS base
+FROM ubuntu:22.10 AS base
 ENV DEBIAN_FRONTEND noninteractive
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; \
     echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache

--- a/egison/Makefile
+++ b/egison/Makefile
@@ -14,7 +14,7 @@ egison-linux-$(ARCH).tar.gz:
 	  amd64) touch egison-linux-$(ARCH).tar.gz ;; \
 	  arm64) \
 	    docker image build -t $(DOCKER_IMAGE_NAME) --progress plain . ; \
-	    docker run --rm -v $(CURDIR):/root/pkg $(DOCKER_IMAGE_NAME) /build.sh $(EGISON_VERSION) ;; \
+	    docker run --rm -v $(CURDIR):/root/pkg $(DOCKER_IMAGE_NAME) /root/pkg/build.sh $(EGISON_VERSION) ;; \
 	esac
 
 clean:

--- a/prefetch_files.sh
+++ b/prefetch_files.sh
@@ -22,16 +22,16 @@ download() {
 }
 
 # go
-if [ "$arch" = "amd64" ]; then download https://dl.google.com/go/go1.18.1.linux-amd64.tar.gz go.tar.gz; fi
-if [ "$arch" = "arm64" ]; then download https://dl.google.com/go/go1.18.1.linux-arm64.tar.gz go.tar.gz; fi
+if [ "$arch" = "amd64" ]; then download https://dl.google.com/go/go1.19.2.linux-amd64.tar.gz go.tar.gz; fi
+if [ "$arch" = "arm64" ]; then download https://dl.google.com/go/go1.19.2.linux-arm64.tar.gz go.tar.gz; fi
 
 # julia
-if [ "$arch" = "amd64" ]; then download https://julialang-s3.julialang.org/bin/linux/x64/1.6/julia-1.6.6-linux-x86_64.tar.gz      julia.tar.gz; fi
-if [ "$arch" = "arm64" ]; then download https://julialang-s3.julialang.org/bin/linux/aarch64/1.6/julia-1.6.6-linux-aarch64.tar.gz julia.tar.gz; fi
+if [ "$arch" = "amd64" ]; then download https://julialang-s3.julialang.org/bin/linux/x64/1.8/julia-1.8.2-linux-x86_64.tar.gz      julia.tar.gz; fi
+if [ "$arch" = "arm64" ]; then download https://julialang-s3.julialang.org/bin/linux/aarch64/1.8/julia-1.8.2-linux-aarch64.tar.gz julia.tar.gz; fi
 
 # openjdk
-if [ "$arch" = "amd64" ]; then download https://download.java.net/java/GA/jdk18.0.1/3f48cabb83014f9fab465e280ccf630b/10/GPL/openjdk-18.0.1_linux-x64_bin.tar.gz     openjdk.tar.gz; fi
-if [ "$arch" = "arm64" ]; then download https://download.java.net/java/GA/jdk18.0.1/3f48cabb83014f9fab465e280ccf630b/10/GPL/openjdk-18.0.1_linux-aarch64_bin.tar.gz openjdk.tar.gz; fi
+if [ "$arch" = "amd64" ]; then download https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_linux-x64_bin.tar.gz     openjdk.tar.gz; fi
+if [ "$arch" = "arm64" ]; then download https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_linux-aarch64_bin.tar.gz openjdk.tar.gz; fi
 
 # nodejs
 node_version="$(curl -s https://nodejs.org/dist/index.json | jq -r '[.[]|select(.lts)][0].version')"


### PR DESCRIPTION
いつも通り、バージョン固定しているいくつかのパッケージをアップデートします。
Circle CI の Free プランで arm.large が使えるようになってたようなので、試しに CircleCI のリソースクラスも変更してみますが、効果がなければ戻そうと思います。