### PR TITLE
Ubuntu 23.04 対応

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,10 @@ version: 2.1
 executors:
   builder:
     machine:
-      image: ubuntu-2204:2022.10.1  # https://circleci.com/docs/configuration-reference/#available-linux-machine-images-cloud
+      image: ubuntu-2204:2023.04.2  # https://circleci.com/docs/configuration-reference/#available-linux-machine-images-cloud
   deployer:
     docker:
-      - image: cimg/base:2022.10-22.04  # https://circleci.com/developer/ja/images/image/cimg/base
+      - image: cimg/base:2023.04-22.04  # https://circleci.com/developer/ja/images/image/cimg/base
 
 commands:
   build-image:

--- a/Dockerfile
+++ b/Dockerfile
@@ -283,7 +283,7 @@ RUN --mount=type=bind,target=/var/lib/apt/lists,from=apt-cache,source=/var/lib/a
      datamash \
      dateutils \
      dc \
-     dotnet6 \
+     dotnet7 \
      faketime \
      ffmpeg \
      figlet \
@@ -384,9 +384,9 @@ COPY --from=nodejs-builder /usr/local/nodejs /usr/local/nodejs
 ENV PATH $PATH:/usr/local/nodejs/bin
 
 # .NET
-COPY --from=dotnet-builder /noc/LICENSE /noc/README.md /noc/noc/noc/bin/Release/net6.0/linux-*/publish/noc /usr/local/noc/
+COPY --from=dotnet-builder /noc/LICENSE /noc/README.md /noc/noc/noc/bin/Release/net7.0/linux-*/publish/noc /usr/local/noc/
 RUN ln -s /usr/local/noc/noc /usr/local/bin/noc
-COPY --from=dotnet-builder /ocs/LICENSE /ocs/README.md /ocs/ocs/bin/Release/net6.0/linux-*/publish/ /usr/local/ocs/
+COPY --from=dotnet-builder /ocs/LICENSE /ocs/README.md /ocs/ocs/bin/Release/net7.0/linux-*/publish/ /usr/local/ocs/
 RUN ln -s /usr/local/ocs/ocs /usr/local/bin/ocs
 
 # Rust
@@ -441,7 +441,7 @@ RUN --mount=type=bind,target=/downloads,from=general-builder,source=/downloads \
       mkdir /usr/local/jsoftware \
       && tar xf /downloads/j.tar.gz -C /usr/local/jsoftware --strip-components 1; \
     fi
-ENV PATH $PATH:/usr/local/jsoftware/bin
+ENV PATH /usr/local/jsoftware/bin:$PATH
 
 # bat, osquery
 RUN --mount=type=bind,target=/downloads,from=general-builder,source=/downloads \

--- a/docker_image.bats
+++ b/docker_image.bats
@@ -76,7 +76,7 @@ bats_require_minimum_version 1.5.0
 }
 
 @test "Brainf*ck" {
-  run -0 bash -c "echo '+++++++++[>+++++++++<-]>++.<+++++++++[>++<-]>+++.---.+++++++..<+++++++++[>----<-]>-.<+++++++++[>+++<-]>+++.++++.' | bf /dev/stdin"
+  run -0 bash -c "echo '+++++++++[>+++++++++<-]>++.<+++++++++[>++<-]>+++.---.+++++++..<+++++++++[>----<-]>-.<+++++++++[>+++<-]>+++.++++.' | hsbrainfuck"
   [ "$output" = 'ShellGei' ]
 }
 
@@ -188,8 +188,8 @@ bats_require_minimum_version 1.5.0
 }
 
 @test "dotnet" {
-  run -129 dotnet --help
-  [[ "${lines[0]}" =~ "Usage: dotnet" ]]
+  run -0 dotnet --help
+  [[ "${lines[0]}" =~ ".NET SDK" ]]
 }
 
 @test "eachdo" {
@@ -591,9 +591,9 @@ bats_require_minimum_version 1.5.0
   [ "$output" = 'シェル芸' ]
 }
 
-@test "Not python2" {
+@test "python is python3" {
   run -0 python --version
-  [[ ! "$output" =~ 'Python 2.' ]]
+  [[ "$output" =~ 'Python 3' ]]
 }
 
 @test "num-utils" {

--- a/docker_image.bats
+++ b/docker_image.bats
@@ -189,7 +189,7 @@ bats_require_minimum_version 1.5.0
 
 @test "dotnet" {
   run -0 dotnet --help
-  [[ "${lines[0]}" =~ ".NET SDK" ]]
+  [[ "${lines[0]}" == ".NET 7.0 へようこそ!" ]]
 }
 
 @test "eachdo" {

--- a/prefetch_files.sh
+++ b/prefetch_files.sh
@@ -22,16 +22,12 @@ download() {
 }
 
 # go
-if [ "$arch" = "amd64" ]; then download https://dl.google.com/go/go1.19.2.linux-amd64.tar.gz go.tar.gz; fi
-if [ "$arch" = "arm64" ]; then download https://dl.google.com/go/go1.19.2.linux-arm64.tar.gz go.tar.gz; fi
+if [ "$arch" = "amd64" ]; then download https://dl.google.com/go/go1.20.3.linux-amd64.tar.gz go.tar.gz; fi
+if [ "$arch" = "arm64" ]; then download https://dl.google.com/go/go1.20.3.linux-arm64.tar.gz go.tar.gz; fi
 
 # julia
-if [ "$arch" = "amd64" ]; then download https://julialang-s3.julialang.org/bin/linux/x64/1.8/julia-1.8.2-linux-x86_64.tar.gz      julia.tar.gz; fi
-if [ "$arch" = "arm64" ]; then download https://julialang-s3.julialang.org/bin/linux/aarch64/1.8/julia-1.8.2-linux-aarch64.tar.gz julia.tar.gz; fi
-
-# openjdk
-if [ "$arch" = "amd64" ]; then download https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_linux-x64_bin.tar.gz     openjdk.tar.gz; fi
-if [ "$arch" = "arm64" ]; then download https://download.java.net/java/GA/jdk19.0.1/afdd2e245b014143b62ccb916125e3ce/10/GPL/openjdk-19.0.1_linux-aarch64_bin.tar.gz openjdk.tar.gz; fi
+if [ "$arch" = "amd64" ]; then download https://julialang-s3.julialang.org/bin/linux/x64/1.8/julia-1.8.5-linux-x86_64.tar.gz      julia.tar.gz; fi
+if [ "$arch" = "arm64" ]; then download https://julialang-s3.julialang.org/bin/linux/aarch64/1.8/julia-1.8.5-linux-aarch64.tar.gz julia.tar.gz; fi
 
 # nodejs
 node_version="$(curl -s https://nodejs.org/dist/index.json | jq -r '[.[]|select(.lts)][0].version')"


### PR DESCRIPTION
## pip 関連

root ユーザーで `pip3` を使って system-wide にパッケージを入れようとすると、[PEP 668](https://peps.python.org/pep-0668/) でインストールできない。
`--break-system-packages` で無理矢理入れても良いが、あまり行儀がよくなさそう。

<details>
<summary>

```sh
# pip3 install yq
```

</summary>

```log
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.

    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.

    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.

    See /usr/share/doc/python3.11/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP 668 for the detailed specification.
```

</details>

apt パッケージマネージャーでインストールできるものは apt で管理し、各ツールで個別に必要なライブラリは virtual env を使う方針で対応してみる。

## .NET

dotnet / dotnet-sdk が公式リポジトリに入ったようなので、apt でインストールするように修正。
noc/ocs の対象フレームワークが  dotnet6 で、 dotnet-sdk-7.0 でビルドはできるものの、実行には dotnet6 が必要な模様。

@xztaityozx dotnet7 に対応してもらえたらアップデート可

## 削除されたパッケージ対応

- bf : 代わりに hsbrainfuck を入れといた
- fortunes-off : 削除 😢 
- haskell-platform: 直接 ghc を入れるようにした

