### PR TITLE
Ubuntu 23.10 対応

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,10 +40,7 @@ commands:
           command: |
             sudo apt update -qq
             sudo apt install -y -qq moreutils
-            mkdir ~/opt
-            tar xf prefetched/*/nodejs.tar.gz -C ~/opt --strip-components 1
-            PATH=${PATH}:~/opt/bin npm install --global --silent --no-progress tap-xunit
-            echo "export PATH=${PATH}:~/opt/bin" >> ${BASH_ENV}
+            npm install --global --silent --no-progress tap-xunit
       - run:
           name: Test a docker image
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,10 @@ version: 2.1
 executors:
   builder:
     machine:
-      image: ubuntu-2204:2023.04.2  # https://circleci.com/docs/configuration-reference/#available-linux-machine-images-cloud
+      image: ubuntu-2204:2023.10.1  # https://circleci.com/docs/configuration-reference/#available-linux-machine-images-cloud
   deployer:
     docker:
-      - image: cimg/base:2023.04-22.04  # https://circleci.com/developer/ja/images/image/cimg/base
+      - image: cimg/base:2023.10-22.04  # https://circleci.com/developer/ja/images/image/cimg/base
 
 commands:
   build-image:

--- a/Dockerfile
+++ b/Dockerfile
@@ -365,7 +365,8 @@ COPY --from=go-builder /root/go/bin /root/go/bin
 COPY --from=go-builder /tmp/usr/local/go /usr/local/go
 COPY --from=go-builder /tmp/root/go /root/go
 COPY --from=go-builder /usr/local/src/noto-emoji/png/128/ /usr/local/src/noto-emoji
-ENV GOPATH /root/go
+# https://github.com/golang/go/issues/61921
+ENV GOROOT /usr/local/go
 ENV PATH $PATH:/usr/local/go/bin:/root/go/bin
 RUN ln -s /root/go/src/github.com/YuheiNakasaka/sayhuuzoku/db /
 ENV TEXTIMG_EMOJI_DIR /usr/local/src/noto-emoji

--- a/Dockerfile
+++ b/Dockerfile
@@ -122,9 +122,11 @@ FROM base AS nim-builder
 ARG TARGETARCH
 RUN mkdir nim \
     && if [ "${TARGETARCH}" = "amd64" ]; then \
-      curl -sfSL --retry 5 https://nim-lang.org/download/nim-1.6.16-linux_x64.tar.xz -o nim.tar.xz \
+      curl -sfSL --retry 5 https://nim-lang.org/download/nim-2.0.0-linux_x64.tar.xz -o nim.tar.xz \
       && tar xf nim.tar.xz --strip-components 1 -C nim \
-      && (cd nim/; ./install.sh /usr/local/bin && cp ./bin/nimble /usr/local/bin/) \
+      && (cd nim/; ./install.sh /usr/local/bin) \
+      && cp ./nim/bin/nimble /usr/local/bin/ \
+      && cp -r ./nim/lib /usr/local/lib/nim/; \
     fi
 RUN if [ "${TARGETARCH}" = "amd64" ]; then nimble install edens gyaric maze rect svgo eachdo -Y; fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # syntax = docker/dockerfile:latest
-FROM ubuntu:23.04 AS apt-cache
+FROM ubuntu:23.10 AS apt-cache
 RUN apt-get update
 
-FROM ubuntu:23.04 AS base
+FROM ubuntu:23.10 AS base
 ENV DEBIAN_FRONTEND noninteractive
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; \
     echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
@@ -107,7 +107,7 @@ RUN curl -sfSL --retry 5 https://sh.rustup.rs | sh -s -- -y
 ENV PATH $PATH:/root/.cargo/bin
 RUN cargo install --git https://github.com/lotabout/rargs.git
 RUN cargo install --git https://github.com/KoharaKazuya/forest.git
-RUN cargo install --git https://github.com/o2sh/onefetch.git --tag 2.17.1
+RUN cargo install --git https://github.com/o2sh/onefetch.git --tag 2.18.1
 RUN cargo install --git https://github.com/greymd/teip.git
 RUN cargo install --git https://github.com/xztaityozx/surge.git
 RUN if [ "${TARGETARCH}" = "amd64" ]; then cargo install --git https://github.com/ryuichiueda/ke2daira.git; fi
@@ -122,7 +122,7 @@ FROM base AS nim-builder
 ARG TARGETARCH
 RUN mkdir nim \
     && if [ "${TARGETARCH}" = "amd64" ]; then \
-      curl -sfSL --retry 5 https://nim-lang.org/download/nim-1.6.12-linux_x64.tar.xz -o nim.tar.xz \
+      curl -sfSL --retry 5 https://nim-lang.org/download/nim-2.0.0-linux_x64.tar.xz -o nim.tar.xz \
       && tar xf nim.tar.xz --strip-components 1 -C nim \
       && (cd nim/; ./install.sh /usr/local/bin && cp ./bin/nimble /usr/local/bin/) \
     fi
@@ -171,12 +171,12 @@ COPY prefetched/mecab-ipadic/mecab-ipadic-2.7.0-20070801.tar.gz mecab-ipadic-neo
 RUN mkdir mecab-ipadic-neologd-utf8
 RUN mecab-ipadic-neologd/bin/install-mecab-ipadic-neologd -u -y -p /downloads/mecab-ipadic-neologd-utf8
 # bat
-RUN curl -sfSL --retry 5 https://github.com/sharkdp/bat/releases/download/v0.23.0/bat_0.23.0_${TARGETARCH}.deb -o bat.deb
+RUN curl -sfSL --retry 5 https://github.com/sharkdp/bat/releases/download/v0.24.0/bat_0.24.0_${TARGETARCH}.deb -o bat.deb
 # osquery
-RUN curl -sfSL --retry 5 https://github.com/osquery/osquery/releases/download/5.8.2/osquery_5.8.2-1.linux_${TARGETARCH}.deb -o osquery.deb
+RUN curl -sfSL --retry 5 https://github.com/osquery/osquery/releases/download/5.10.2/osquery_5.10.2-1.linux_${TARGETARCH}.deb -o osquery.deb
 # J
 RUN if [ "${TARGETARCH}" = "amd64" ]; then \
-      curl -sfSL --retry 5 http://www.jsoftware.com/download/j903/install/j903_linux64.tar.gz -o j.tar.gz; \
+      curl -sfSL --retry 5 http://www.jsoftware.com/download/j904/install/j904_linux64.tar.gz -o j.tar.gz; \
     fi
 
 # Egison
@@ -187,9 +187,9 @@ COPY prefetched/$TARGETARCH/julia.tar.gz .
 # Clojure
 RUN curl -sfSL --retry 5 https://download.clojure.org/install/linux-install-1.11.1.1105.sh -o clojure_install.sh
 # trdsql
-RUN curl -sfSL --retry 5 https://github.com/noborus/trdsql/releases/download/v0.11.1/trdsql_v0.11.1_linux_${TARGETARCH}.zip -o trdsql.zip
+RUN curl -sfSL --retry 5 https://github.com/noborus/trdsql/releases/download/v0.12.1/trdsql_v0.12.1_linux_${TARGETARCH}.zip -o trdsql.zip
 # PowerShell
-ENV POWERSHELL_VERSION 7.3.4
+ENV POWERSHELL_VERSION 7.3.9
 RUN case ${TARGETARCH} in \
       amd64) curl -sfSL --retry 5 https://github.com/PowerShell/PowerShell/releases/download/v$POWERSHELL_VERSION/powershell-$POWERSHELL_VERSION-linux-x64.tar.gz   -o powershell.tar.gz ;; \
       arm64) curl -sfSL --retry 5 https://github.com/PowerShell/PowerShell/releases/download/v$POWERSHELL_VERSION/powershell-$POWERSHELL_VERSION-linux-arm64.tar.gz -o powershell.tar.gz ;; \
@@ -269,7 +269,6 @@ RUN if [ "${TARGETARCH}" = "amd64" ]; then \
 RUN --mount=type=bind,target=/var/lib/apt/lists,from=apt-cache,source=/var/lib/apt/lists \
     --mount=type=cache,target=/var/cache/apt \
     apt-get install -y -qq \
-     agrep \
      apache2-utils \
      ash yash \
      bbe \
@@ -297,6 +296,7 @@ RUN --mount=type=bind,target=/var/lib/apt/lists,from=apt-cache,source=/var/lib/a
      gawk \
      gdb \
      ghc \
+     glimpse \
      gnuplot \
      graphviz \
      icu-devtools \
@@ -308,13 +308,13 @@ RUN --mount=type=bind,target=/var/lib/apt/lists,from=apt-cache,source=/var/lib/a
      language-pack-ja \
      libc++-dev \
      libkkc-utils \
-     libncurses5 \
+     libncurses6 \
      libnss3 libgdk3.0-cil \
      libmecab-dev \
      librsvg2-bin \
      libskk-dev \
      libxml2-utils \
-     lua5.4 php8.1 php8.1-cli php8.1-common \
+     lua5.4 php8.2 php8.2-cli php8.2-common \
      mecab mecab-ipadic mecab-ipadic-utf8 \
      mono-csharp-shell \
      moreutils \
@@ -451,9 +451,9 @@ RUN --mount=type=bind,target=/downloads,from=general-builder,source=/downloads \
 RUN --mount=type=bind,target=/downloads,from=general-builder,source=/downloads \
     tar xf /downloads/julia.tar.gz -C /usr/local \
     && unzip /downloads/trdsql.zip -d /usr/local \
-    && ln -s /usr/local/trdsql_v0.11.1_linux_*/trdsql /usr/local/bin \
+    && ln -s /usr/local/trdsql_v0.12.1_linux_*/trdsql /usr/local/bin \
     && /bin/bash /downloads/clojure_install.sh
-ENV PATH $PATH:/usr/local/julia-1.8.5/bin
+ENV PATH $PATH:/usr/local/julia-1.9.3/bin
 # Clojure が実行時に必要とするパッケージを取得
 RUN clojure -e '(println "test")'
 # Clojure ワンライナー
@@ -477,7 +477,7 @@ RUN mv /usr/bin/man.REAL /usr/bin/man
 
 # reset apt config
 RUN rm /etc/apt/apt.conf.d/keep-cache /etc/apt/apt.conf.d/no-install-recommends
-COPY --from=ubuntu:23.04 /etc/apt/apt.conf.d/docker-clean /etc/apt/apt.conf.d/
+COPY --from=ubuntu:23.10 /etc/apt/apt.conf.d/docker-clean /etc/apt/apt.conf.d/
 
 # ShellgeiBot-Image information
 RUN mkdir -p /etc/shellgeibot-image

--- a/Dockerfile
+++ b/Dockerfile
@@ -122,7 +122,7 @@ FROM base AS nim-builder
 ARG TARGETARCH
 RUN mkdir nim \
     && if [ "${TARGETARCH}" = "amd64" ]; then \
-      curl -sfSL --retry 5 https://nim-lang.org/download/nim-2.0.0-linux_x64.tar.xz -o nim.tar.xz \
+      curl -sfSL --retry 5 https://nim-lang.org/download/nim-1.6.16-linux_x64.tar.xz -o nim.tar.xz \
       && tar xf nim.tar.xz --strip-components 1 -C nim \
       && (cd nim/; ./install.sh /usr/local/bin && cp ./bin/nimble /usr/local/bin/) \
     fi
@@ -176,7 +176,7 @@ RUN curl -sfSL --retry 5 https://github.com/sharkdp/bat/releases/download/v0.24.
 RUN curl -sfSL --retry 5 https://github.com/osquery/osquery/releases/download/5.10.2/osquery_5.10.2-1.linux_${TARGETARCH}.deb -o osquery.deb
 # J
 RUN if [ "${TARGETARCH}" = "amd64" ]; then \
-      curl -sfSL --retry 5 http://www.jsoftware.com/download/j904/install/j904_linux64.tar.gz -o j.tar.gz; \
+      curl -sfSL --retry 5 https://www.jsoftware.com/download/j9.4/install/j9.4_linux64.tar.gz -o j.tar.gz; \
     fi
 
 # Egison
@@ -348,7 +348,7 @@ RUN --mount=type=bind,target=/var/lib/apt/lists,from=apt-cache,source=/var/lib/a
      tree \
      ttyrec \
      unicode-data uniutils \
-     vim emacs-nox \
+     vim \
      w3m nginx \
      whiptail \
      xvfb xterm x11-apps xdotool \

--- a/docker_image.bats
+++ b/docker_image.bats
@@ -230,11 +230,6 @@ bats_require_minimum_version 1.5.0
   [ "$output" = '京急大師線' ]
 }
 
-@test "Emacs" {
-  run -0 bash -c "echo シェル芸 | emacs -Q --batch --insert /dev/stdin --eval='(princ (buffer-string))'"
-  [ "$output" = シェル芸 ]
-}
-
 @test "faker" {
   run -0 faker name
 }

--- a/docker_image.bats
+++ b/docker_image.bats
@@ -12,6 +12,7 @@ bats_require_minimum_version 1.5.0
   [[ "$output" =~ abc2midi ]]
 }
 
+# glimpse で入る
 @test "agrep" {
   run -0 bash -c "echo unko | agrep -2 miko"
   [ "$output" = "unko" ]

--- a/prefetch_files.sh
+++ b/prefetch_files.sh
@@ -22,12 +22,12 @@ download() {
 }
 
 # go
-if [ "$arch" = "amd64" ]; then download https://dl.google.com/go/go1.20.3.linux-amd64.tar.gz go.tar.gz; fi
-if [ "$arch" = "arm64" ]; then download https://dl.google.com/go/go1.20.3.linux-arm64.tar.gz go.tar.gz; fi
+if [ "$arch" = "amd64" ]; then download https://go.dev/dl/go1.21.3.linux-amd64.tar.gz go.tar.gz; fi
+if [ "$arch" = "arm64" ]; then download https://go.dev/dl/go1.21.3.linux-arm64.tar.gz go.tar.gz; fi
 
 # julia
-if [ "$arch" = "amd64" ]; then download https://julialang-s3.julialang.org/bin/linux/x64/1.8/julia-1.8.5-linux-x86_64.tar.gz      julia.tar.gz; fi
-if [ "$arch" = "arm64" ]; then download https://julialang-s3.julialang.org/bin/linux/aarch64/1.8/julia-1.8.5-linux-aarch64.tar.gz julia.tar.gz; fi
+if [ "$arch" = "amd64" ]; then download https://julialang-s3.julialang.org/bin/linux/x64/1.9/julia-1.9.3-linux-x86_64.tar.gz      julia.tar.gz; fi
+if [ "$arch" = "arm64" ]; then download https://julialang-s3.julialang.org/bin/linux/aarch64/1.9/julia-1.9.3-linux-aarch64.tar.gz julia.tar.gz; fi
 
 # nodejs
 node_version="$(curl -s https://nodejs.org/dist/index.json | jq -r '[.[]|select(.lts)][0].version')"


### PR DESCRIPTION
## 概要・タスク

- Ubuntu 23.10 対応
    - [x] ベースイメージを Ubuntu 23.10 に更新
    - [x] agrep がないよって警告が出るので、代わりに glimpse をインストール
- [x] バージョンを固定しているソフトウェアを最新版に更新
- テストが落ちるケースの対応
    - [x] emacs → 削除する方針
    - [x] sayhuuzoku → `GOROOT` 環境変数を設定
- その他
    - [x] CircleCI executor のイメージを更新 
    - [x] x86_64 版でテストコマンドが実行されない → circle ci executor デフォルトの node.js を使用

## メモ・詳細
### .NET

- .NET 8.0 が出ているが、noc / ocs が未対応のため 7.0 のままにしておく

### Emacs

- Emacs 29 になって、標準入力からの読み込みでエラーが出る

<details>

```sh
# echo シェル芸 | emacs -Q --batch --insert /dev/stdin --eval='(princ (buffer-string))'

Error: error ("Maximum buffer size exceeded")
  mapbacktrace(#f(compiled-function (evald func args flags) #<bytecode 0x15a506725bae92bf>))
  debug-early-backtrace()
  debug-early(error (error "Maximum buffer size exceeded"))
  command-line-1(("--insert" "/dev/stdin" "--eval=(princ (buffer-string))"))
  command-line()
  normal-top-level()
Maximum buffer size exceeded
```
</details>

- あんまり使われてない気がするし、（私が）メンテできないので一旦削除でも良いのではないか
- 誰か対応できる人がいたらお願いしたい

### sayhuuzoku

- `/db/data.db` の読み込みに失敗する

<details>

```sh
# sayhuuzoku g
2023/10/28 07:06:55 Failed to connect db: Failed to find path to database: exit status 2
```

</details>

- sayhuuzoku は、`go env GOPATH` の実行結果に、`db/data.db` のパスを追加している
  - https://github.com/YuheiNakasaka/sayhuuzoku/blob/a2f148bcb9f7b587a1893682980793fc65812834/db/db.go#L24-L38
- go1.21 では、`go` コマンドが `$GOROOT/bin/go` 以下にあることを期待している？
  - https://github.com/golang/go/issues/61921
  - 実行プログラムをビルドしたパスと異なるパスに配置した際に問題になる？
  - とりあえず `GOPATH` の代わりに `GOROOT` を指定して解消

### Nim

- nim 2.0.0 がリリースされていたため更新
- `nimble install` 実行時に `/usr/local/lib/nim/lib` 以下にライブラリが配置されていることを想定しているようだが、 `install.sh` を実行しても配置されないようなので、自前で配置
