### PR TITLE
update Ubuntu 24.04

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,10 +3,10 @@ version: 2.1
 executors:
   builder:
     machine:
-      image: ubuntu-2204:2023.10.1  # https://circleci.com/docs/configuration-reference/#available-linux-machine-images-cloud
+      image: ubuntu-2204:2024.04.4  # https://circleci.com/docs/configuration-reference/#available-linux-machine-images-cloud
   deployer:
     docker:
-      - image: cimg/base:2023.10-22.04  # https://circleci.com/developer/ja/images/image/cimg/base
+      - image: cimg/base:2024.06-22.04  # https://circleci.com/developer/ja/images/image/cimg/base
 
 commands:
   build-image:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # syntax = docker/dockerfile:latest
-FROM ubuntu:23.10 AS apt-cache
+FROM ubuntu:24.04 AS apt-cache
 RUN apt-get update
 
-FROM ubuntu:23.10 AS base
+FROM ubuntu:24.04 AS base
 ENV DEBIAN_FRONTEND noninteractive
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; \
     echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
@@ -84,18 +84,18 @@ ENV PATH $PATH:/usr/local/nodejs/bin
 RUN --mount=type=cache,target=/root/.npm \
     npm install -g --silent faker-cli chemi fx yukichant @amanoese/muscular kana2ipa bats
 
-## .NET
-FROM base AS dotnet-builder
-ARG TARGETARCH
-RUN --mount=type=bind,target=/var/lib/apt/lists,from=apt-cache,source=/var/lib/apt/lists \
-    --mount=type=cache,target=/var/cache/apt,sharing=private \
-    apt-get install -y -qq dotnet-sdk-7.0
-# noc
-RUN git clone --depth 1 https://github.com/xztaityozx/noc.git
-RUN (cd /noc/noc/noc; dotnet publish --configuration Release -p:PublishSingleFile=true -p:PublishReadyToRun=true --runtime linux-$(echo $TARGETARCH | sed 's/amd64/x64/') --self-contained false)
-# ocs
-RUN git clone --depth 1 https://github.com/xztaityozx/ocs.git
-RUN (cd /ocs/ocs; dotnet publish --configuration Release --runtime linux-$(echo $TARGETARCH | sed 's/amd64/x64/') --self-contained false ocs.csproj)
+# ## .NET
+# FROM base AS dotnet-builder
+# ARG TARGETARCH
+# RUN --mount=type=bind,target=/var/lib/apt/lists,from=apt-cache,source=/var/lib/apt/lists \
+#     --mount=type=cache,target=/var/cache/apt,sharing=private \
+#     apt-get install -y -qq dotnet-sdk-8.0
+# # noc
+# RUN git clone --depth 1 https://github.com/xztaityozx/noc.git
+# RUN (cd /noc/noc/noc; dotnet publish --configuration Release -p:PublishSingleFile=true -p:PublishReadyToRun=true --runtime linux-$(echo $TARGETARCH | sed 's/amd64/x64/') --self-contained false)
+# # ocs
+# RUN git clone --depth 1 https://github.com/xztaityozx/ocs.git
+# RUN (cd /ocs/ocs; dotnet publish --configuration Release --runtime linux-$(echo $TARGETARCH | sed 's/amd64/x64/') --self-contained false ocs.csproj)
 
 ## Rust
 FROM base AS rust-builder
@@ -122,7 +122,7 @@ FROM base AS nim-builder
 ARG TARGETARCH
 RUN mkdir nim \
     && if [ "${TARGETARCH}" = "amd64" ]; then \
-      curl -sfSL --retry 5 https://nim-lang.org/download/nim-2.0.0-linux_x64.tar.xz -o nim.tar.xz \
+      curl -sfSL --retry 5 https://nim-lang.org/download/nim-2.0.4-linux_x64.tar.xz -o nim.tar.xz \
       && tar xf nim.tar.xz --strip-components 1 -C nim \
       && (cd nim/; ./install.sh /usr/local/bin) \
       && cp ./nim/bin/nimble /usr/local/bin/ \
@@ -175,10 +175,10 @@ RUN mecab-ipadic-neologd/bin/install-mecab-ipadic-neologd -u -y -p /downloads/me
 # bat
 RUN curl -sfSL --retry 5 https://github.com/sharkdp/bat/releases/download/v0.24.0/bat_0.24.0_${TARGETARCH}.deb -o bat.deb
 # osquery
-RUN curl -sfSL --retry 5 https://github.com/osquery/osquery/releases/download/5.10.2/osquery_5.10.2-1.linux_${TARGETARCH}.deb -o osquery.deb
+RUN curl -sfSL --retry 5 https://github.com/osquery/osquery/releases/download/5.12.2/osquery_5.12.2-1.linux_${TARGETARCH}.deb -o osquery.deb
 # J
 RUN if [ "${TARGETARCH}" = "amd64" ]; then \
-      curl -sfSL --retry 5 https://www.jsoftware.com/download/j9.4/install/j9.4_linux64.tar.gz -o j.tar.gz; \
+      curl -sfSL --retry 5 https://www.jsoftware.com/download/j9.5/install/j9.5_linux64.tar.gz -o j.tar.gz; \
     fi
 
 # Egison
@@ -187,11 +187,11 @@ RUN if [ "${TARGETARCH}" = "amd64" ]; then curl -sfSL https://github.com/egison/
 # Julia
 COPY prefetched/$TARGETARCH/julia.tar.gz .
 # Clojure
-RUN curl -sfSL --retry 5 https://download.clojure.org/install/linux-install-1.11.1.1105.sh -o clojure_install.sh
+RUN curl -sfSL --retry 5 https://download.clojure.org/install/linux-install-1.11.3.1463.sh -o clojure_install.sh
 # trdsql
-RUN curl -sfSL --retry 5 https://github.com/noborus/trdsql/releases/download/v0.12.1/trdsql_v0.12.1_linux_${TARGETARCH}.zip -o trdsql.zip
+RUN curl -sfSL --retry 5 https://github.com/noborus/trdsql/releases/download/v1.0.0/trdsql_v1.0.0_linux_${TARGETARCH}.zip -o trdsql.zip
 # PowerShell
-ENV POWERSHELL_VERSION 7.3.9
+ENV POWERSHELL_VERSION 7.4.2
 RUN case ${TARGETARCH} in \
       amd64) curl -sfSL --retry 5 https://github.com/PowerShell/PowerShell/releases/download/v$POWERSHELL_VERSION/powershell-$POWERSHELL_VERSION-linux-x64.tar.gz   -o powershell.tar.gz ;; \
       arm64) curl -sfSL --retry 5 https://github.com/PowerShell/PowerShell/releases/download/v$POWERSHELL_VERSION/powershell-$POWERSHELL_VERSION-linux-arm64.tar.gz -o powershell.tar.gz ;; \
@@ -289,7 +289,7 @@ RUN --mount=type=bind,target=/var/lib/apt/lists,from=apt-cache,source=/var/lib/a
      datamash \
      dateutils \
      dc \
-     dotnet7 \
+     dotnet8 \
      faketime \
      ffmpeg \
      figlet \
@@ -322,7 +322,7 @@ RUN --mount=type=bind,target=/var/lib/apt/lists,from=apt-cache,source=/var/lib/a
      librsvg2-bin \
      libskk-dev \
      libxml2-utils \
-     lua5.4 php8.2 php8.2-cli php8.2-common \
+     lua5.4 php8.3 php8.3-cli php8.3-common \
      mecab mecab-ipadic mecab-ipadic-utf8 \
      mono-csharp-shell \
      moreutils \
@@ -333,7 +333,7 @@ RUN --mount=type=bind,target=/var/lib/apt/lists,from=apt-cache,source=/var/lib/a
      num-utils \
      numconv \
      nyancat \
-     openjdk-20-jdk \
+     openjdk-21-jdk \
      pandoc \
      parallel \
      perl \
@@ -392,11 +392,11 @@ COPY --from=python-builder /usr/local/bin/concat /usr/local/bin/concat
 COPY --from=nodejs-builder /usr/local/nodejs /usr/local/nodejs
 ENV PATH $PATH:/usr/local/nodejs/bin
 
-# .NET
-COPY --from=dotnet-builder /noc/LICENSE /noc/README.md /noc/noc/noc/bin/Release/net7.0/linux-*/publish/noc /usr/local/noc/
-RUN ln -s /usr/local/noc/noc /usr/local/bin/noc
-COPY --from=dotnet-builder /ocs/LICENSE /ocs/README.md /ocs/ocs/bin/Release/net7.0/linux-*/publish/ /usr/local/ocs/
-RUN ln -s /usr/local/ocs/ocs /usr/local/bin/ocs
+# # .NET
+# COPY --from=dotnet-builder /noc/LICENSE /noc/README.md /noc/noc/noc/bin/Release/net7.0/linux-*/publish/noc /usr/local/noc/
+# RUN ln -s /usr/local/noc/noc /usr/local/bin/noc
+# COPY --from=dotnet-builder /ocs/LICENSE /ocs/README.md /ocs/ocs/bin/Release/net7.0/linux-*/publish/ /usr/local/ocs/
+# RUN ln -s /usr/local/ocs/ocs /usr/local/bin/ocs
 
 # Rust
 COPY --from=rust-builder /root/.cargo/bin /root/.cargo/bin
@@ -460,9 +460,9 @@ RUN --mount=type=bind,target=/downloads,from=general-builder,source=/downloads \
 RUN --mount=type=bind,target=/downloads,from=general-builder,source=/downloads \
     tar xf /downloads/julia.tar.gz -C /usr/local \
     && unzip /downloads/trdsql.zip -d /usr/local \
-    && ln -s /usr/local/trdsql_v0.12.1_linux_*/trdsql /usr/local/bin \
+    && ln -s /usr/local/trdsql_v1.0.0_linux_*/trdsql /usr/local/bin \
     && /bin/bash /downloads/clojure_install.sh
-ENV PATH $PATH:/usr/local/julia-1.9.3/bin
+ENV PATH $PATH:/usr/local/julia-1.10.4/bin
 # Clojure が実行時に必要とするパッケージを取得
 RUN clojure -e '(println "test")'
 # Clojure ワンライナー
@@ -486,7 +486,7 @@ RUN mv /usr/bin/man.REAL /usr/bin/man
 
 # reset apt config
 RUN rm /etc/apt/apt.conf.d/keep-cache /etc/apt/apt.conf.d/no-install-recommends
-COPY --from=ubuntu:23.10 /etc/apt/apt.conf.d/docker-clean /etc/apt/apt.conf.d/
+COPY --from=ubuntu:24.04 /etc/apt/apt.conf.d/docker-clean /etc/apt/apt.conf.d/
 
 # ShellgeiBot-Image information
 RUN mkdir -p /etc/shellgeibot-image

--- a/Dockerfile
+++ b/Dockerfile
@@ -84,18 +84,18 @@ ENV PATH $PATH:/usr/local/nodejs/bin
 RUN --mount=type=cache,target=/root/.npm \
     npm install -g --silent faker-cli chemi fx yukichant @amanoese/muscular kana2ipa bats
 
-# ## .NET
-# FROM base AS dotnet-builder
-# ARG TARGETARCH
-# RUN --mount=type=bind,target=/var/lib/apt/lists,from=apt-cache,source=/var/lib/apt/lists \
-#     --mount=type=cache,target=/var/cache/apt,sharing=private \
-#     apt-get install -y -qq dotnet-sdk-8.0
-# # noc
-# RUN git clone --depth 1 https://github.com/xztaityozx/noc.git
-# RUN (cd /noc/noc/noc; dotnet publish --configuration Release -p:PublishSingleFile=true -p:PublishReadyToRun=true --runtime linux-$(echo $TARGETARCH | sed 's/amd64/x64/') --self-contained false)
-# # ocs
-# RUN git clone --depth 1 https://github.com/xztaityozx/ocs.git
-# RUN (cd /ocs/ocs; dotnet publish --configuration Release --runtime linux-$(echo $TARGETARCH | sed 's/amd64/x64/') --self-contained false ocs.csproj)
+## .NET
+FROM base AS dotnet-builder
+ARG TARGETARCH
+RUN --mount=type=bind,target=/var/lib/apt/lists,from=apt-cache,source=/var/lib/apt/lists \
+    --mount=type=cache,target=/var/cache/apt,sharing=private \
+    apt-get install -y -qq dotnet-sdk-8.0
+# noc
+RUN git clone --depth 1 https://github.com/xztaityozx/noc.git
+RUN (cd /noc/noc/noc; dotnet publish --configuration Release -p:PublishSingleFile=true -p:PublishReadyToRun=true --runtime linux-$(echo $TARGETARCH | sed 's/amd64/x64/') --self-contained false)
+# ocs
+RUN git clone --depth 1 https://github.com/xztaityozx/ocs.git
+RUN (cd /ocs/ocs; dotnet publish --configuration Release --runtime linux-$(echo $TARGETARCH | sed 's/amd64/x64/') --self-contained false ocs.csproj)
 
 ## Rust
 FROM base AS rust-builder
@@ -392,11 +392,11 @@ COPY --from=python-builder /usr/local/bin/concat /usr/local/bin/concat
 COPY --from=nodejs-builder /usr/local/nodejs /usr/local/nodejs
 ENV PATH $PATH:/usr/local/nodejs/bin
 
-# # .NET
-# COPY --from=dotnet-builder /noc/LICENSE /noc/README.md /noc/noc/noc/bin/Release/net7.0/linux-*/publish/noc /usr/local/noc/
-# RUN ln -s /usr/local/noc/noc /usr/local/bin/noc
-# COPY --from=dotnet-builder /ocs/LICENSE /ocs/README.md /ocs/ocs/bin/Release/net7.0/linux-*/publish/ /usr/local/ocs/
-# RUN ln -s /usr/local/ocs/ocs /usr/local/bin/ocs
+# .NET
+COPY --from=dotnet-builder /noc/LICENSE /noc/README.md /noc/noc/noc/bin/Release/net8.0/linux-*/publish/noc /usr/local/noc/
+RUN ln -s /usr/local/noc/noc /usr/local/bin/noc
+COPY --from=dotnet-builder /ocs/LICENSE /ocs/README.md /ocs/ocs/bin/Release/net8.0/linux-*/publish/ /usr/local/ocs/
+RUN ln -s /usr/local/ocs/ocs /usr/local/bin/ocs
 
 # Rust
 COPY --from=rust-builder /root/.cargo/bin /root/.cargo/bin

--- a/docker_image.bats
+++ b/docker_image.bats
@@ -128,13 +128,13 @@ bats_require_minimum_version 1.5.0
   [ "$output" = '[30m  \x1b[30m  [m[31m  \x1b[31m  [m[32m  \x1b[32m  [m[33m  \x1b[33m  [m[34m  \x1b[34m  [m[35m  \x1b[35m  [m[36m  \x1b[36m  [m[37m  \x1b[37m  [m' ]
 }
 
-# @test "concat" {
-#   run -0 concat cat
-#   [ "${lines[0]}" = " /\    /" ]
-#   [ "${lines[1]}" = "(' )  ( " ]
-#   [ "${lines[2]}" = " (  \  )" ]
-#   [ "${lines[3]}" = " |(__)/ " ]
-# }
+@test "concat" {
+  run -0 concat cat
+  [ "${lines[0]}" = " /\    /" ]
+  [ "${lines[1]}" = "(' )  ( " ]
+  [ "${lines[2]}" = " (  \  )" ]
+  [ "${lines[3]}" = " |(__)/ " ]
+}
 
 @test "cowsay" {
   run -0 cowsay シェル芸

--- a/docker_image.bats
+++ b/docker_image.bats
@@ -81,11 +81,6 @@ bats_require_minimum_version 1.5.0
   [ "$output" = 'ShellGei' ]
 }
 
-@test "bsdgames" {
-  run -0 bash -c "echo '... .... . .-.. .-.. --. . ..  ...-.-' | morse -d"
-  [ "$output" = "SHELLGEI" ]
-}
-
 @test "build-essential" {
   run -0 gcc --version
   [[ "${lines[0]}" =~ gcc ]]
@@ -133,13 +128,13 @@ bats_require_minimum_version 1.5.0
   [ "$output" = '[30m  \x1b[30m  [m[31m  \x1b[31m  [m[32m  \x1b[32m  [m[33m  \x1b[33m  [m[34m  \x1b[34m  [m[35m  \x1b[35m  [m[36m  \x1b[36m  [m[37m  \x1b[37m  [m' ]
 }
 
-@test "concat" {
-  run -0 concat cat
-  [ "${lines[0]}" = " /\    /" ]
-  [ "${lines[1]}" = "(' )  ( " ]
-  [ "${lines[2]}" = " (  \  )" ]
-  [ "${lines[3]}" = " |(__)/ " ]
-}
+# @test "concat" {
+#   run -0 concat cat
+#   [ "${lines[0]}" = " /\    /" ]
+#   [ "${lines[1]}" = "(' )  ( " ]
+#   [ "${lines[2]}" = " (  \  )" ]
+#   [ "${lines[3]}" = " |(__)/ " ]
+# }
 
 @test "cowsay" {
   run -0 cowsay シェル芸
@@ -190,7 +185,7 @@ bats_require_minimum_version 1.5.0
 
 @test "dotnet" {
   run -0 dotnet --help
-  [[ "${lines[0]}" == ".NET 7.0 へようこそ!" ]]
+  [[ "${lines[0]}" == ".NET 8.0 へようこそ!" ]]
 }
 
 @test "eachdo" {
@@ -582,10 +577,10 @@ bats_require_minimum_version 1.5.0
   run -0 nms -v
 }
 
-@test "noc" {
-  run -0 noc --decode 部邊邊󠄓邊󠄓邉邉󠄊邊邊󠄒邊󠄓邊󠄓邉邉󠄊辺邉󠄊邊邊󠄓邊󠄓邉邉󠄎辺邉󠄎邊辺󠄀邉邉󠄈辺邉󠄍邊邊󠄓部
-  [ "$output" = 'シェル芸' ]
-}
+# @test "noc" {
+#   run -0 noc --decode 部邊邊󠄓邊󠄓邉邉󠄊邊邊󠄒邊󠄓邊󠄓邉邉󠄊辺邉󠄊邊邊󠄓邊󠄓邉邉󠄎辺邉󠄎邊辺󠄀邉邉󠄈辺邉󠄍邊邊󠄓部
+#   [ "$output" = 'シェル芸' ]
+# }
 
 @test "python is python3" {
   run -0 python --version
@@ -617,10 +612,10 @@ bats_require_minimum_version 1.5.0
   [ "${lines[0]}" = "Terminal Nyancat" ]
 }
 
-@test "ocs" {
-  run -0 sh -c "seq 10 | ocs 'BEGIN{var sum=0}{sum+=int.Parse(F0)}END{Console.WriteLine(sum)}'"
-  [ $output -eq 55 ]
-}
+# @test "ocs" {
+#   run -0 sh -c "seq 10 | ocs 'BEGIN{var sum=0}{sum+=int.Parse(F0)}END{Console.WriteLine(sum)}'"
+#   [ $output -eq 55 ]
+# }
 
 @test "ojichat" {
   run -0 ojichat --version

--- a/docker_image.bats
+++ b/docker_image.bats
@@ -577,10 +577,10 @@ bats_require_minimum_version 1.5.0
   run -0 nms -v
 }
 
-# @test "noc" {
-#   run -0 noc --decode 部邊邊󠄓邊󠄓邉邉󠄊邊邊󠄒邊󠄓邊󠄓邉邉󠄊辺邉󠄊邊邊󠄓邊󠄓邉邉󠄎辺邉󠄎邊辺󠄀邉邉󠄈辺邉󠄍邊邊󠄓部
-#   [ "$output" = 'シェル芸' ]
-# }
+@test "noc" {
+  run -0 noc --decode 部邊邊󠄓邊󠄓邉邉󠄊邊邊󠄒邊󠄓邊󠄓邉邉󠄊辺邉󠄊邊邊󠄓邊󠄓邉邉󠄎辺邉󠄎邊辺󠄀邉邉󠄈辺邉󠄍邊邊󠄓部
+  [ "$output" = 'シェル芸' ]
+}
 
 @test "python is python3" {
   run -0 python --version
@@ -612,10 +612,10 @@ bats_require_minimum_version 1.5.0
   [ "${lines[0]}" = "Terminal Nyancat" ]
 }
 
-# @test "ocs" {
-#   run -0 sh -c "seq 10 | ocs 'BEGIN{var sum=0}{sum+=int.Parse(F0)}END{Console.WriteLine(sum)}'"
-#   [ $output -eq 55 ]
-# }
+@test "ocs" {
+  run -0 sh -c "seq 10 | ocs 'BEGIN{var sum=0}{sum+=int.Parse(F0)}END{Console.WriteLine(sum)}'"
+  [ $output -eq 55 ]
+}
 
 @test "ojichat" {
   run -0 ojichat --version

--- a/prefetch_files.sh
+++ b/prefetch_files.sh
@@ -22,12 +22,12 @@ download() {
 }
 
 # go
-if [ "$arch" = "amd64" ]; then download https://go.dev/dl/go1.21.3.linux-amd64.tar.gz go.tar.gz; fi
-if [ "$arch" = "arm64" ]; then download https://go.dev/dl/go1.21.3.linux-arm64.tar.gz go.tar.gz; fi
+if [ "$arch" = "amd64" ]; then download https://go.dev/dl/go1.22.4.linux-amd64.tar.gz go.tar.gz; fi
+if [ "$arch" = "arm64" ]; then download https://go.dev/dl/go1.22.4.linux-arm64.tar.gz go.tar.gz; fi
 
-# julia
-if [ "$arch" = "amd64" ]; then download https://julialang-s3.julialang.org/bin/linux/x64/1.9/julia-1.9.3-linux-x86_64.tar.gz      julia.tar.gz; fi
-if [ "$arch" = "arm64" ]; then download https://julialang-s3.julialang.org/bin/linux/aarch64/1.9/julia-1.9.3-linux-aarch64.tar.gz julia.tar.gz; fi
+# julia; https://julialang.org/downloads/#official_binaries_for_manual_download
+if [ "$arch" = "amd64" ]; then download https://julialang-s3.julialang.org/bin/linux/x64/1.10/julia-1.10.4-linux-x86_64.tar.gz    julia.tar.gz; fi
+if [ "$arch" = "arm64" ]; then download https://julialang-s3.julialang.org/bin/linux/aarch64/1.10/julia-1.10.4-linux-aarch64.tar.gz julia.tar.gz; fi
 
 # nodejs
 node_version="$(curl -s https://nodejs.org/dist/index.json | jq -r '[.[]|select(.lts)][0].version')"


### PR DESCRIPTION
## 変更点

- morse
    - bsdgames に morse が含まれなくなった模様
    - morsegen が別にあるため、ASCII -> モールスは変換できるが、逆変換のコマンドが見当たらない

## 要対応

以下コマンドのインストール/テストは一旦コメントアウトしている。

- [x] [concat](https://github.com/yabeenico/concat)
    - Python 3.12 対応が必要
        - https://github.com/yabeenico/concat/pull/5
- [x] noc, ocs
    - .NET 8.0 対応が必要 @xztaityozx

## egison 関連で試行錯誤した際のメモ書き
### 背景

現状では、egison の x86_64 版は https://github.com/egison/egison-package-builder/releases から .deb パッケージを取得し、aarch64 版は Ubuntu 22.04 の Docker 環境を用意して自前でビルドしている。
egison は [egzact](https://github.com/greymd/egzact) のためにインストールしている。
egison のビルドには Haskell (GHC / Cabal) 環境が必要だが、[Haskell Platform](https://www.haskell.org/platform/) が非推奨となり、Ubuntu 22.04 より後のバージョンの apt リポジトリには含まれなくなった。

### Haskell 環境

Ubuntu 24.04 では、haskell-platform の代わりに ghc-9.4.7, cabal-install-3.8.1.0 をインストールすることができる。
ただし、依存で template-haskell-2.19.0.0 が入り egison-4.1.3 から sweet-egison-0.1.1.3 => egison-pattern-src-th-mode => template-haskell>=2.2.0 && <2.17 と依存関係を辿った際に、依存ライブラリバージョンのコンフリクトを起こす。
egison-4.1.3 は GHC 8.x に依存している？（詳しくないので状況から推測）

https://www.haskell.org/ghcup/install/#version-23 を参考に GHCup で ghc-8.10.7, cabal をインストールすることは可能。
これで egison のビルドが通るかと思いきや、ライブラリのインストール時に LLVM の古いバージョンが必要になる模様。
https://gitlab.haskell.org/ghc/ghc/-/wikis/commentary/compiler/backends/llvm/installing#llvm-support を見ると、LLVM 9 が要求されるようだが、Ubuntu 24.04 の apt リポジトリからインストール可能な LLVM のバージョンは 14〜18 のみ。
[LLVM で用意されている apt リポジトリ](https://apt.llvm.org/noble/pool/main/l/) でも、インストール可能な LLVM のバージョンは 17〜19 のみ。
LLVM を自前でビルドするか、どこかの Docker イメージを持ってくるかだが、それは手間とビルドの時間がかかりすぎるので断念した。

egison のビルド環境は、とりあえずは引き続き Ubuntu 22.04 版を使い続けるので良いかなぁと考えている。