### PR TITLE
concat の引数にスペースを含む場合に正常に動作しない問題の修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ RUN git clone --depth 1 https://github.com/yabeenico/concat
 RUN (cd /downloads/concat && git archive --format=tar --prefix=concat/ HEAD) | tar xf - -C /usr/local
 RUN python3 -m venv /usr/local/concat
 RUN /usr/local/concat/bin/pip3 install -r /usr/local/concat/requirements.txt
-RUN echo '/usr/local/concat/bin/python3 /usr/local/concat/concat.py $@' > /usr/local/bin/concat && chmod +x /usr/local/bin/concat
+RUN echo '/usr/local/concat/bin/python3 /usr/local/concat/concat.py "$@"' > /usr/local/bin/concat && chmod +x /usr/local/bin/concat
 
 ## Node.js
 FROM base AS nodejs-builder

--- a/docker_image.bats
+++ b/docker_image.bats
@@ -129,11 +129,11 @@ bats_require_minimum_version 1.5.0
 }
 
 @test "concat" {
-  run -0 concat cat
-  [ "${lines[0]}" = " /\    /" ]
-  [ "${lines[1]}" = "(' )  ( " ]
-  [ "${lines[2]}" = " (  \  )" ]
-  [ "${lines[3]}" = " |(__)/ " ]
+  run -0 concat 'cat * 2'
+  [ "${lines[0]}" = " /\    /  /\    /" ]
+  [ "${lines[1]}" = "(' )  (  (' )  ( " ]
+  [ "${lines[2]}" = " (  \  )  (  \  )" ]
+  [ "${lines[3]}" = " |(__)/   |(__)/ " ]
 }
 
 @test "cowsay" {


### PR DESCRIPTION
## 事象

```sh
$ concat 'cat * 2'
 /\    /
(' )  (
 (  \  )
 |(__)/
```

concat に空白を含む引数を与えた際、先頭しか処理されない。

## 要因

`/usr/local/bin/concat` に配置している concat ラッパースクリプトでのクォート不足。

https://github.com/theoremoon/ShellgeiBot-Image/blob/45e5fb94ffd71bd708c18137d32a98b183be07bb/Dockerfile#L75C69-L75C71
