### PR TITLE
onefetch のビルド失敗対応

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -107,7 +107,7 @@ RUN curl -sfSL --retry 5 https://sh.rustup.rs | sh -s -- -y
 ENV PATH $PATH:/root/.cargo/bin
 RUN cargo install --git https://github.com/lotabout/rargs.git
 RUN cargo install --git https://github.com/KoharaKazuya/forest.git
-RUN cargo install --git https://github.com/o2sh/onefetch.git --tag 2.18.1
+RUN cargo install --git https://github.com/o2sh/onefetch.git --tag 2.21.0
 RUN cargo install --git https://github.com/greymd/teip.git
 RUN cargo install --git https://github.com/xztaityozx/surge.git
 RUN if [ "${TARGETARCH}" = "amd64" ]; then cargo install --git https://github.com/ryuichiueda/ke2daira.git; fi


### PR DESCRIPTION
## 事象

- 7/26 から onefetch のビルドが失敗するようになった
  - [#2035](https://app.circleci.com/pipelines/github/theoremoon/ShellgeiBot-Image/2035/workflows/84468c38-002d-424f-96ad-a924f4e06184)
  - [#2036](https://app.circleci.com/pipelines/github/theoremoon/ShellgeiBot-Image/2036/workflows/8809e50c-adde-431a-9ede-2fa9e0891b50)

## 要因

onefetch が依存する gix-url v0.19.0 のコンパイルに失敗している。

<details>

```log
#13 32.55    Compiling gix-url v0.19.0
#13 32.61 error[E0283]: type annotations needed
#13 32.61    --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/gix-url-0.19.0/src/lib.rs:105:54
#13 32.61     |
#13 32.61 105 |             let path = gix_path::from_bstr(self.path.as_ref());
#13 32.61     |                                                      ^^^^^^
#13 32.61     |
#13 32.61     = note: multiple `impl`s satisfying `BString: AsRef<_>` found in the `bstr` crate:
#13 32.61             - impl AsRef<BStr> for BString;
#13 32.61             - impl AsRef<[u8]> for BString;
#13 32.61 help: try using a fully qualified path to specify the expected types
#13 32.61     |
#13 32.61 105 |             let path = gix_path::from_bstr(<BString as AsRef<T>>::as_ref(&self.path));
#13 32.61     |                                            +++++++++++++++++++++++++++++++         ~
#13 32.61
#13 32.61 error[E0283]: type annotations needed
#13 32.61    --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/gix-url-0.19.0/src/lib.rs:105:24
#13 32.61     |
#13 32.61 105 |             let path = gix_path::from_bstr(self.path.as_ref());
#13 32.61     |                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ cannot infer type for reference `&_`
#13 32.61     |
#13 32.61     = note: multiple `impl`s satisfying `Cow<'_, BStr>: From<&_>` found in the `bstr` crate:
#13 32.61             - impl<'a> From<&'a BStr> for Cow<'a, BStr>;
#13 32.61             - impl<'a> From<&'a BString> for Cow<'a, BStr>;
#13 32.61     = note: required for `&_` to implement `Into<Cow<'_, BStr>>`
#13 32.61 note: required by a bound in `from_bstr`
#13 32.61    --> /root/.cargo/registry/src/index.crates.io-6f17d22bba15001f/gix-path-0.8.4/src/convert.rs:126:34
#13 32.61     |
#13 32.61 126 | pub fn from_bstr<'a>(input: impl Into<Cow<'a, BStr>>) -> Cow<'a, Path> {
#13 32.61     |                                  ^^^^^^^^^^^^^^^^^^^ required by this bound in `from_bstr`
#13 32.61
#13 32.65 For more information about this error, try `rustc --explain E0283`.
#13 32.65 error: could not compile `gix-url` (lib) due to 2 previous errors
#13 32.65 warning: build failed, waiting for other jobs to finish...
#13 41.03 error: failed to compile `onefetch v2.18.1 (https://github.com/o2sh/onefetch.git?tag=2.18.1#dccd5a8c)`, intermediate artifacts can be found at `/tmp/cargo-installQnjO2p`.
#13 41.03 To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
#13 ERROR: process "/bin/sh -c cargo install --git https://github.com/o2sh/onefetch.git --tag 2.18.1" did not complete successfully: exit code: 101
```

</details>

詳しくないが、おそらくこの辺り？
https://github.com/Byron/gitoxide/issues/1466

## 対応

- onefetch の最新版ならビルドできそう

