### PR TITLE
Go パッケージのインストールエラー解消

### DIFF
--- a/prefetch_files.sh
+++ b/prefetch_files.sh
@@ -22,8 +22,8 @@ download() {
 }
 
 # go
-if [ "$arch" = "amd64" ]; then download https://go.dev/dl/go1.22.4.linux-amd64.tar.gz go.tar.gz; fi
-if [ "$arch" = "arm64" ]; then download https://go.dev/dl/go1.22.4.linux-arm64.tar.gz go.tar.gz; fi
+if [ "$arch" = "amd64" ]; then download https://go.dev/dl/go1.24.1.linux-amd64.tar.gz go.tar.gz; fi
+if [ "$arch" = "arm64" ]; then download https://go.dev/dl/go1.24.1.linux-arm64.tar.gz go.tar.gz; fi
 
 # julia; https://julialang.org/downloads/#official_binaries_for_manual_download
 if [ "$arch" = "amd64" ]; then download https://julialang-s3.julialang.org/bin/linux/x64/1.10/julia-1.10.4-linux-x86_64.tar.gz    julia.tar.gz; fi


### PR DESCRIPTION
go 1.22.4 ではビルドできなくなっていたため、go 1.24.1 に更新

```sh
$ go install github.com/ericchiang/pup@latest
go: downloading github.com/ericchiang/pup v0.4.0
go: finding module for package golang.org/x/text/transform
go: finding module for package golang.org/x/net/html/charset
go: finding module for package golang.org/x/net/html
go: finding module for package github.com/mattn/go-colorable
go: finding module for package golang.org/x/net/html/atom
go: finding module for package github.com/fatih/color
go: downloading golang.org/x/net v0.37.0
go: downloading golang.org/x/text v0.23.0
go: downloading github.com/fatih/color v1.18.0
go: downloading github.com/mattn/go-colorable v0.1.14
go: toolchain upgrade needed to resolve golang.org/x/net/html
go: golang.org/x/net@v0.37.0 requires go >= 1.23.0 (running go 1.22.4)
```

今まで半年に1回の Ubuntu バージョン更新時に、他パッケージも更新してたので遭遇しなかったが、サボってたら何もしてないのに壊れるようになった。